### PR TITLE
Use SwaggerUI Export for API Docs generation 

### DIFF
--- a/jenkins/aws/buildSwagger.sh
+++ b/jenkins/aws/buildSwagger.sh
@@ -115,9 +115,8 @@ fi
 # Generate documentation
 docker run --rm \
     -v "${tmpdir}:/app/indir" -v "${DIST_DIR}:/app/outdir" \
-    codeontap/utilities swagger2aglio \
-     --input=/app/indir/$(fileName "${TEMP_SWAGGER_SPEC_FILE}") --output=/app/outdir/apidoc.html  \
-     --theme-variables slate --theme-template triple
+    -e SWAGGER_JSON=/app/indir/$(fileName "${TEMP_SWAGGER_SPEC_FILE}") \
+    codeontap/swaggerui-export
 RESULT=$?
 [[ "${RESULT}" -ne 0 ]] && fatal "Swagger file documentation generation failed"
 

--- a/jenkins/aws/manageImages.sh
+++ b/jenkins/aws/manageImages.sh
@@ -126,6 +126,17 @@ for FORMAT in "${FORMATS[@]}"; do
                         -g "${CODE_COMMIT}" \
                         -f "${DOC_FILE}"
                 RESULT=$? && [[ "${RESULT}" -ne 0 ]] && exit
+
+            else
+                DOC_FILE="${AUTOMATION_BUILD_SRC_DIR}/dist/apidoc.zip"
+                
+                if [[ -f "${DOC_FILE}" ]]; then 
+                    ${AUTOMATION_DIR}/manageSwagger.sh -s \
+                            -u "${DEPLOYMENT_UNIT}" \
+                            -g "${CODE_COMMIT}" \
+                            -f "${DOC_FILE}"
+                    RESULT=$? && [[ "${RESULT}" -ne 0 ]] && exit
+                fi
             fi
             ;;
 


### PR DESCRIPTION
Uses a SwaggerUI Export docker container to generate a SwaggerUI based static site for API Documentation. 