### PR TITLE
make venv_dir variable global

### DIFF
--- a/jenkins/aws/buildPython.sh
+++ b/jenkins/aws/buildPython.sh
@@ -13,7 +13,7 @@ function main() {
     { fatal "No requirements.txt - is this really a python base repo?"; return 1; }
   
   # Set up the virtual build environment
-  local venv_dir="$(getTempDir "cota_venv_XXX")"
+  venv_dir="$(getTempDir "cota_venv_XXX")"
   PYTHON_VERSION="${AUTOMATION_PYTHON_VERSION:+ -p } ${AUTOMATION_PYTHON_VERSION}"
 
   # Note that python version below should NOT be in quotes to ensure arguments parsed correctly


### PR DESCRIPTION
so it will be available in trap statement and tmp directories will be cleaned up for failed builds