### PR TITLE
Move required files for SwaggerUI to their own directory

### DIFF
--- a/jenkins/aws/buildSwagger.sh
+++ b/jenkins/aws/buildSwagger.sh
@@ -111,10 +111,13 @@ else
     zip "${SWAGGER_RESULT_FILE}" "${CLEAN_SWAGGER_SPEC_FILE}"
 fi
 
-
 # Generate documentation
+mkdir "${tmpdir}/swaggerUI"
+[[ -f "${TEMP_SWAGGER_SPEC_FILE}" ]] && 
+    cp "${TEMP_SWAGGER_SPEC_FILE}" "${tmpdir}/swaggerUI/"
+
 docker run --rm \
-    -v "${tmpdir}:/app/indir" -v "${DIST_DIR}:/app/outdir" \
+    -v "${tmpdir}/swaggerUI:/app/indir" -v "${DIST_DIR}:/app/outdir" \
     -e SWAGGER_JSON=/app/indir/$(fileName "${TEMP_SWAGGER_SPEC_FILE}") \
     codeontap/swaggerui-export
 RESULT=$?


### PR DESCRIPTION
The swagger UI build process copies everything from the specified indir and adds it to the output zip. 

This currently picks up all files that are created in the tmpdir when it should just have the clean swagger spec. 
