### PR TITLE
Add Content Node build and image management

### DIFF
--- a/jenkins/aws/buildContentStatic.sh
+++ b/jenkins/aws/buildContentStatic.sh
@@ -9,10 +9,10 @@ function main() {
   cd ${AUTOMATION_BUILD_SRC_DIR}
   
   # packge for content node
-  if [[ -d "${AUTOMATION_BUILD_SRC_DIR}/app" ]]; then
+  if [[ -d "${AUTOMATION_BUILD_SRC_DIR}/content" ]]; then
     mkdir -p "${AUTOMATION_BUILD_SRC_DIR}/dist"
     
-    cd "${AUTOMATION_BUILD_SRC_DIR}/app"
+    cd "${AUTOMATION_BUILD_SRC_DIR}/content"
     zip -r "${AUTOMATION_BUILD_SRC_DIR}/dist/contentnode.zip" * 
 
   fi

--- a/jenkins/aws/buildContentStatic.sh
+++ b/jenkins/aws/buildContentStatic.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+[[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
+trap '[[ (-z "${AUTOMATION_DEBUG}") ; exit 1' SIGHUP SIGINT SIGTERM
+. "${AUTOMATION_BASE_DIR}/common.sh"
+
+function main() {
+  # Make sure we are in the build source directory
+  cd ${AUTOMATION_BUILD_SRC_DIR}
+  
+  # packge for content node
+  if [[ -d "${AUTOMATION_BUILD_SRC_DIR}/app" ]]; then
+    mkdir -p "${AUTOMATION_BUILD_SRC_DIR}/dist"
+    
+    cd "${AUTOMATION_BUILD_SRC_DIR}/app"
+    zip -r "${AUTOMATION_BUILD_SRC_DIR}/dist/contentnode.zip" * 
+
+  fi
+
+  # All good
+  return 0
+}
+
+main "$@"
+

--- a/jenkins/aws/manageContentNode.sh
+++ b/jenkins/aws/manageContentNode.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+[[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
+trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
+
+# Note that filename can still overridden via provided parameters
+${AUTOMATION_DIR}/manageS3Registry.sh -y "contentnode" -f "contentnode.zip" "$@"
+RESULT=$?

--- a/jenkins/aws/manageImages.sh
+++ b/jenkins/aws/manageImages.sh
@@ -154,6 +154,20 @@ for FORMAT in "${FORMATS[@]}"; do
             fi
             ;;
 
+        contentnode)
+            IMAGE_FILE="${AUTOMATION_BUILD_SRC_DIR}/dist/contentnode.zip"
+
+            if [[ -f "${IMAGE_FILE}" ]]; then
+                ${AUTOMATION_DIR}/manageContentNode.sh -s \
+                        -u "${DEPLOYMENT_UNIT}" \
+                        -g "${CODE_COMMIT}" \
+                        -f "${IMAGE_FILE}"
+                RESULT=$? && [[ "${RESULT}" -ne 0 ]]&& exit
+            else
+                RESULT=1 && fatal "${IMAGE_FILE} missing" && exit
+            fi
+            ;;
+
         *)
             RESULT=1 && fatal "Unsupported image format \"${FORMAT}\"" && exit
             ;;


### PR DESCRIPTION
Adds support for Content Hubs, which allows for static content to be consolidated to a central location. 

- Adds support for the contentnode image, a zip file containing the content
- Adds support for a static content build which takes the contents of an content folder and zip's int into a file called contentnode.zip 

This zip file is then pulled down to the automation server as part of the content node deployment process.