### PR TITLE
Correct logic for processing multiple accounts

### DIFF
--- a/jenkins/aws/manageAccount.sh
+++ b/jenkins/aws/manageAccount.sh
@@ -5,8 +5,8 @@ trap 'exit 1' SIGHUP SIGINT SIGTERM
 . "${AUTOMATION_BASE_DIR}/common.sh"
 
 function main() {
-  [[-n ACCOUNTS_LIST]] &&
-    TAG="acc${AUTOMATION_JOB_IDENTIFIER}-multiple-accounts" ||
+  [[-n "${ACCOUNTS_LIST}" ]] &&
+    TAG="acc${AUTOMATION_JOB_IDENTIFIER}-${ACCOUNTS_LIST}" ||
     TAG="acc${AUTOMATION_JOB_IDENTIFIER}-${ACCOUNT}"
 
   ${AUTOMATION_DIR}/manageUnits.sh -r "${TAG}" || return $?

--- a/jenkins/aws/manageUnits.sh
+++ b/jenkins/aws/manageUnits.sh
@@ -88,7 +88,19 @@ function main() {
 
     info "Processing account ${account} ...\n"
 
-    export ACCOUNT="${account}"
+    # setContext will have set up for the first account in the list
+    if [[ "${account}" != "${ACCOUNT}" ]]; then
+      export ACCOUNT="${account}"
+
+      info "Getting credentials for account ${account} ...\n"
+
+      . ${AUTOMATION_DIR}/setCredentials.sh "${ACCOUNT}"
+      export ACCOUNT_AWS_ACCESS_KEY_ID_VAR="${AWS_CRED_AWS_ACCESS_KEY_ID_VAR}"
+      export ACCOUNT_AWS_SECRET_ACCESS_KEY_VAR="${AWS_CRED_AWS_SECRET_ACCESS_KEY_VAR}"
+      export ACCOUNT_TEMP_AWS_ACCESS_KEY_ID="${AWS_CRED_TEMP_AWS_ACCESS_KEY_ID}"
+      export ACCOUNT_TEMP_AWS_SECRET_ACCESS_KEY="${AWS_CRED_TEMP_AWS_SECRET_ACCESS_KEY}"
+      export ACCOUNT_TEMP_AWS_SESSION_TOKEN="${AWS_CRED_TEMP_AWS_SESSION_TOKEN}"
+    fi
 
     for level in "${levels_required[@]}"; do
 

--- a/setContext.sh
+++ b/setContext.sh
@@ -31,6 +31,7 @@ DEFAULTS:
 
 RELEASE_MODE = ${RELEASE_MODE_DEFAULT}
 DEPLOYMENT_MODE = ${DEPLOYMENT_MODE_DEFAULT}
+ACCOUNT=\${ACCOUNT_LIST[0]}
 
 NOTES:
 
@@ -359,7 +360,8 @@ function main() {
   
   # Determine the account from the product/segment combination
   # if not already defined or provided on the command line
-  findAndDefineSetting "ACCOUNT" "ACCOUNT" "${PRODUCT}" "${SEGMENT}" "value"
+  arrayFromList accounts_list "${ACCOUNTS_LIST}"
+  findAndDefineSetting "ACCOUNT" "ACCOUNT" "${PRODUCT}" "${SEGMENT}" "value" "${accounts_list[0]}"
   
   # Default account/product git provider - "github"
   # ORG is product specific so not defaulted here


### PR DESCRIPTION
Fixes #56 

As AWS credentials are tied to an account, the credentials need to be changed if switching accounts.