### PR TITLE
Rebase before pus to allow for changes in the repo durign job execution

### DIFF
--- a/jenkins/aws/manageRepo.sh
+++ b/jenkins/aws/manageRepo.sh
@@ -142,6 +142,11 @@ function push() {
 
     # Update upstream repo
     if [[ "${REPO_PUSH_REQUIRED}" == "true" ]]; then
+        trace "Rebasing ${REPO_LOG_NAME} in case of changes..."
+        git rebase ${REPO_REMOTE} ${REPO_BRANCH}
+        RESULT=$? && [[ ${RESULT} -ne 0 ]] && \
+            fatal "Can't rebase the ${REPO_LOG_NAME} repo from upstream ${REPO_REMOTE}" && return 1
+
         trace "Pushing the ${REPO_LOG_NAME} repo upstream..."
         git push --tags ${REPO_REMOTE} ${REPO_BRANCH}
         RESULT=$? && [[ ${RESULT} -ne 0 ]] && \


### PR DESCRIPTION
With increased used of cmdb repos as the target for job outputs, it is more likely a cmdb repo will change while a job is running.

To accommodate this, rebase a changed repo before pushing to improve the chances of the changes being successfully combined.