### PR TITLE
Move consolidated blueprint storage to a dedicated state repo

### DIFF
--- a/contextTree.sh
+++ b/contextTree.sh
@@ -263,7 +263,6 @@ function findGen3TenantInfrastructureDir() {
   local tenant="$1"; shift
 
   findDir "${root_dir}" \
-    "infrastructure/**/${tenant}" \
     "${tenant}/infrastructure"
 }
 

--- a/jenkins/aws/buildTenantBlueprints.sh
+++ b/jenkins/aws/buildTenantBlueprints.sh
@@ -8,7 +8,7 @@ trap '[[ (-z "${AUTOMATION_DEBUG}") ; exit 1' SIGHUP SIGINT SIGTERM
 # This would ideally be tirggered using a git hook from an automation server
 
 function main() {
-    if [[ -z AUTOMATION_REGISTRY_REPO ]]; then
+    if [[ -z "${AUTOMATION_REGISTRY_REPO}" ]]; then
         fatal "No automation registry available"
         return 255
     fi

--- a/jenkins/aws/buildTenantBlueprints.sh
+++ b/jenkins/aws/buildTenantBlueprints.sh
@@ -8,33 +8,29 @@ trap '[[ (-z "${AUTOMATION_DEBUG}") ; exit 1' SIGHUP SIGINT SIGTERM
 # This would ideally be tirggered using a git hook from an automation server
 
 function main() {
+    if [[ -z AUTOMATION_REGISTRY_REPO ]]; then
+        fatal "No automation registry available"
+        return 255
+    fi
+
     # Make sure we are in the build source directory
     cd ${AUTOMATION_BUILD_SRC_DIR}
 
-    # If an Infradocs repo has been setup then clone it, otherwise use the Tenant Infrastructure directory
-    if [[ -n "${INFRADOCS_REPO}" ]]; then
+    local BLUEPRINT_CONSOLIDATION_DIR="${AUTOMATION_BUILD_SRC_DIR}/registry"
 
-        local BLUEPRINT_CONSOLIDATION_DIR="${AUTOMATION_BUILD_SRC_DIR}/repo"
+    ${AUTOMATION_DIR}/manageRepo.sh -c -l "blueprint consolidation" \
+        -n "${AUTOMATION_REGISTRY_REPO}" -v "${ACCOUNT_GIT_PROVIDER}" \
+        -d "${BLUEPRINT_CONSOLIDATION_DIR}" 
 
-        ${AUTOMATION_DIR}/manageRepo.sh -c -l "blueprint consolidation" \
-            -n "${BLUEPRINT_CONSOLIDATION_REPO}" -v "${ACCOUNT_GIT_PROVIDER}" \
-            -d "${BLUEPRINT_CONSOLIDATION_DIR}" 
-    
-        if [[ -n "${INFRADOCS_PREFIX}" ]]; then
-            local BLUEPRINT_CONSOLIDATION_DIR="${AUTOMATION_BUILD_SRC_DIR}/repo/${INFRADOCS_PREFIX}"
-        fi 
-
-    else 
-    
-        local BLUEPRINT_CONSOLIDATION_DIR="${TENANT_INFRASTRUCTURE_DIR}/cot"
-    
-    fi
+    if [[ -n "${INFRADOCS_PREFIX}" ]]; then
+        local BLUEPRINT_CONSOLIDATION_DIR="${AUTOMATION_BUILD_SRC_DIR}/registry/"
+    fi 
 
     local BLUEPRINT_DESTINATION_DIR="${BLUEPRINT_CONSOLIDATION_DIR}/blueprints"
-    local BLUEPRINT_DESTINATION_FILE= "${BLUEPRINT_DESTINATION_DIR}/${TENANT}-${PRODUCT}-${ENVIRONMENT}-${SEGMENT}-blueprint.json"
+    local BLUEPRINT_DESTINATION_FILE="${BLUEPRINT_DESTINATION_DIR}/${TENANT}-${PRODUCT}-${ENVIRONMENT}-${SEGMENT}-blueprint.json"
 
     info "blueprint repo ${BLUEPRINT_DESTINATION_DIR}"
-    
+
     if [[ -f "${AUTOMATION_BUILD_SRC_DIR}/blueprint.json" ]]; then 
 
         if [[ ! -d "${BLUEPRINT_DESTINATION_DIR}" ]]; then 

--- a/jenkins/aws/buildTenantBlueprints.sh
+++ b/jenkins/aws/buildTenantBlueprints.sh
@@ -30,7 +30,8 @@ function main() {
     
     fi
 
-    local BLUEPRINT_DESTINATION_DIR="${BLUEPRINT_CONSOLIDATION_DIR}/blueprints/${TENANT}/${PRODUCT}/${ENVIRONMENT}/${SEGMENT}/"
+    local BLUEPRINT_DESTINATION_DIR="${BLUEPRINT_CONSOLIDATION_DIR}/blueprints"
+    local BLUEPRINT_DESTINATION_FILE= "${BLUEPRINT_DESTINATION_DIR}/${TENANT}-${PRODUCT}-${ENVIRONMENT}-${SEGMENT}-blueprint.json"
 
     info "blueprint repo ${BLUEPRINT_DESTINATION_DIR}"
     
@@ -41,13 +42,13 @@ function main() {
         fi 
 
         echo "Adding Blueprint to Tenant Infrastructure..."
-        cp "${AUTOMATION_BUILD_SRC_DIR}/blueprint.json" "${BLUEPRINT_DESTINATION_DIR}/blueprint.json"
+        cp "${AUTOMATION_BUILD_SRC_DIR}/blueprint.json" "${BLUEPRINT_DESTINATION_FILE}"
     
     else
 
-        if [[ -f "${BLUEPRINT_DESTINATION_DIR}/blueprint.json" ]]; then 
+        if [[ -f "${BLUEPRINT_DESTINATION_FILE}" ]]; then 
             echo "Removing Blueprint from Tenant Infrastructure..."
-            rm "${BLUEPRINT_DESTINATION_DIR}/blueprint.json"
+            rm "${BLUEPRINT_DESTINATION_FILE}"
         fi 
     fi
 


### PR DESCRIPTION
The updates to blueprints will get pretty busy once multiple applications start uploading. At the moment they are being stored in the account infrastructure repo but this has the potential to cause issues with the history of the account repo. 

Instead the blueprints should be consolidated in a standalone repo which is treated as a temporary storage space. This will act like a code repo, with builds being triggered to create the infrastructure documentation