### PR TITLE
Include API docs in Swagger Management

### DIFF
--- a/jenkins/aws/manageBuildReferences.sh
+++ b/jenkins/aws/manageBuildReferences.sh
@@ -474,6 +474,7 @@ for ((INDEX=0; INDEX<${#DEPLOYMENT_UNIT_ARRAY[@]}; INDEX++)); do
                                     ;;
                                 swagger)
                                     ${AUTOMATION_DIR}/manageSwagger.sh -x -p -a "${IMAGE_PROVIDER}" -u "${CURRENT_DEPLOYMENT_UNIT}" -g "${CODE_COMMIT}"  -r "${VERIFICATION_TAG}" -z "${FROM_IMAGE_PROVIDER}"
+                                    ${AUTOMATION_DIR}/manageSwagger.sh -x -p -a "${IMAGE_PROVIDER}" -u "${CURRENT_DEPLOYMENT_UNIT}" -g "${CODE_COMMIT}"  -r "${VERIFICATION_TAG}" -z "${FROM_IMAGE_PROVIDER}" -f "apidoc.zip"
                                     RESULT=$?
                                     ;;
                                 spa)

--- a/jenkins/aws/manageSwagger.sh
+++ b/jenkins/aws/manageSwagger.sh
@@ -5,5 +5,6 @@ trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
 
 # Note that filename can still overridden via provided parameters
 ${AUTOMATION_DIR}/manageS3Registry.sh -x -y "swagger" -f "swagger.zip" "$@"
+${AUTOMATION_DIR}/manageS3Registry.sh -x -y "swagger" -f "apidoc.zip" "$@"
 RESULT=$?
 

--- a/jenkins/aws/manageSwagger.sh
+++ b/jenkins/aws/manageSwagger.sh
@@ -5,10 +5,7 @@ trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
 
 # Note that filename can still overridden via provided parameters
 ${AUTOMATION_DIR}/manageS3Registry.sh -x -y "swagger" -f "swagger.zip" "$@"
-
-if [[ -f "apidoc.zip" ]]; then 
-    ${AUTOMATION_DIR}/manageS3Registry.sh -x -y "swagger" -f "apidoc.zip" "$@"
-fi
+${AUTOMATION_DIR}/manageS3Registry.sh -x -y "swagger" -f "apidoc.zip" "$@"
 
 RESULT=$?
 

--- a/jenkins/aws/manageSwagger.sh
+++ b/jenkins/aws/manageSwagger.sh
@@ -5,6 +5,10 @@ trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
 
 # Note that filename can still overridden via provided parameters
 ${AUTOMATION_DIR}/manageS3Registry.sh -x -y "swagger" -f "swagger.zip" "$@"
-${AUTOMATION_DIR}/manageS3Registry.sh -x -y "swagger" -f "apidoc.zip" "$@"
+
+if [[ -f "apidoc.zip" ]]; then 
+    ${AUTOMATION_DIR}/manageS3Registry.sh -x -y "swagger" -f "apidoc.zip" "$@"
+fi
+
 RESULT=$?
 

--- a/jenkins/aws/manageSwagger.sh
+++ b/jenkins/aws/manageSwagger.sh
@@ -5,7 +5,6 @@ trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
 
 # Note that filename can still overridden via provided parameters
 ${AUTOMATION_DIR}/manageS3Registry.sh -x -y "swagger" -f "swagger.zip" "$@"
-${AUTOMATION_DIR}/manageS3Registry.sh -x -y "swagger" -f "apidoc.zip" "$@"
 
 RESULT=$?
 


### PR DESCRIPTION
The API Docs zip file is not being included in the Swagger release process, add the apidocs.zip file to the copy process

The apidocs.zip file is always produced on a swagger build. The choice to use it is up to the solution configuration.