### PR TITLE
Update Permissions on Jekyll generated sites to allow deletion

### DIFF
--- a/jenkins/aws/buildInfraDocs.sh
+++ b/jenkins/aws/buildInfraDocs.sh
@@ -46,6 +46,10 @@ function main() {
 
   # Package for spa if required
   if [[ -f "${AUTOMATION_BUILD_SRC_DIR}/_site/${JEKYLL_DEFAULT_PAGE}" ]]; then
+    
+    # Allow access to all files that have been generated so they can be cleaned up. 
+    chmod -R a+rwx  "${AUTOMATION_BUILD_SRC_DIR}/_site"
+
     mkdir -p "${AUTOMATION_BUILD_SRC_DIR}/dist"
     
     cd "${AUTOMATION_BUILD_SRC_DIR}/_site"

--- a/jenkins/aws/buildJekyll.sh
+++ b/jenkins/aws/buildJekyll.sh
@@ -50,6 +50,10 @@ function main() {
     
   # Package for spa if required
   if [[ -f "${AUTOMATION_BUILD_SRC_DIR}/_site/${JEKYLL_DEFAULT_PAGE}" ]]; then
+
+    # Allow access to all files that have been generated so they can be cleaned up. 
+    chmod -R a+rwx  "${AUTOMATION_BUILD_SRC_DIR}/_site"
+
     mkdir -p "${AUTOMATION_BUILD_SRC_DIR}/dist"
     
     cd "${AUTOMATION_BUILD_SRC_DIR}/_site"


### PR DESCRIPTION
The automation process is currently throwing errors that it can't remove files created under the _site directory created by Jekyll. 

The _site folder is created in the build process with full access, but the files are being created with their own permissions. 

If files exist, give full control to all processes for the files so that any user can remove them ( Jenkins user) 