### PR TITLE
Adding render support to modelBender content builds

### DIFF
--- a/jenkins/aws/buildContentModelBender.sh
+++ b/jenkins/aws/buildContentModelBender.sh
@@ -9,16 +9,26 @@ function main() {
   cd ${AUTOMATION_BUILD_SRC_DIR}
   
   # Create Build folders for Jenkins Permissions
+  mkdir -p ${AUTOMATION_BUILD_SRC_DIR}/stage
+  chmod a+rwx ${AUTOMATION_BUILD_SRC_DIR}/stage
+
   mkdir -p ${AUTOMATION_BUILD_SRC_DIR}/outdir
   chmod a+rwx ${AUTOMATION_BUILD_SRC_DIR}/outdir
 
   # run Model Bender build using Docker Build image 
-  info "Running ModelBender build..."
+  info "Running ModelBender enterprise tasks..."
   docker run --rm \
     --volume="${AUTOMATION_BUILD_SRC_DIR}:/work/indir" \
-    --volume="${AUTOMATION_BUILD_SRC_DIR}/outdir:/work/outdir" \
+    --volume="${AUTOMATION_BUILD_SRC_DIR}/stage:/work/outdir" \
     codeontap/modelbender:latest \
     enterprise --indir=indir --outdir=outdir
+
+  info "Rendering ModelBender content..."
+  docker run --rm \
+    --volume="${AUTOMATION_BUILD_SRC_DIR}/stage:/work/indir" \
+    --volume="${AUTOMATION_BUILD_SRC_DIR}/outdir:/work/outdir" \
+    codeontap/modelbender:latest \
+    render --indir=indir --outdir=outdir
 
   mkdir -p "${AUTOMATION_BUILD_SRC_DIR}/dist"
   


### PR DESCRIPTION
To generate the static content we need model bender has two stages, the enterprise stage which builds the model bender code based on the enterprise configuration and then render stage which builds the html/png content that we are after.

This adds the render stage to our build process