### PR TITLE
Fix modelbender rendering output

### DIFF
--- a/jenkins/aws/buildContentModelBender.sh
+++ b/jenkins/aws/buildContentModelBender.sh
@@ -9,9 +9,6 @@ function main() {
   cd ${AUTOMATION_BUILD_SRC_DIR}
   
   # Create Build folders for Jenkins Permissions
-  mkdir -p ${AUTOMATION_BUILD_SRC_DIR}/stage
-  chmod a+rwx ${AUTOMATION_BUILD_SRC_DIR}/stage
-
   mkdir -p ${AUTOMATION_BUILD_SRC_DIR}/outdir
   chmod a+rwx ${AUTOMATION_BUILD_SRC_DIR}/outdir
 
@@ -25,10 +22,9 @@ function main() {
 
   info "Rendering ModelBender content..."
   docker run --rm \
-    --volume="${AUTOMATION_BUILD_SRC_DIR}/stage:/work/indir" \
-    --volume="${AUTOMATION_BUILD_SRC_DIR}/outdir:/work/outdir" \
+    --volume="${AUTOMATION_BUILD_SRC_DIR}/outdir:/work/indir" \
     codeontap/modelbender:latest \
-    render --indir=indir --outdir=outdir
+    render --indir=indir
 
   mkdir -p "${AUTOMATION_BUILD_SRC_DIR}/dist"
   

--- a/jenkins/aws/buildContentModelBender.sh
+++ b/jenkins/aws/buildContentModelBender.sh
@@ -16,7 +16,7 @@ function main() {
   info "Running ModelBender enterprise tasks..."
   docker run --rm \
     --volume="${AUTOMATION_BUILD_SRC_DIR}:/work/indir" \
-    --volume="${AUTOMATION_BUILD_SRC_DIR}/stage:/work/outdir" \
+    --volume="${AUTOMATION_BUILD_SRC_DIR}/outdir:/work/outdir" \
     codeontap/modelbender:latest \
     enterprise --indir=indir --outdir=outdir
 

--- a/jenkins/aws/buildContentModelBender.sh
+++ b/jenkins/aws/buildContentModelBender.sh
@@ -9,26 +9,26 @@ function main() {
   cd ${AUTOMATION_BUILD_SRC_DIR}
   
   # Create Build folders for Jenkins Permissions
-  mkdir -p ${AUTOMATION_BUILD_SRC_DIR}/outdir
-  chmod a+rwx ${AUTOMATION_BUILD_SRC_DIR}/outdir
+  mkdir -p ${AUTOMATION_BUILD_SRC_DIR}/stage
+  chmod a+rwx ${AUTOMATION_BUILD_SRC_DIR}/stage
 
   # run Model Bender build using Docker Build image 
   info "Running ModelBender enterprise tasks..."
   docker run --rm \
     --volume="${AUTOMATION_BUILD_SRC_DIR}:/work/indir" \
-    --volume="${AUTOMATION_BUILD_SRC_DIR}/outdir:/work/outdir" \
+    --volume="${AUTOMATION_BUILD_SRC_DIR}/stage:/work/outdir" \
     codeontap/modelbender:latest \
     enterprise --indir=indir --outdir=outdir
 
   info "Rendering ModelBender content..."
   docker run --rm \
-    --volume="${AUTOMATION_BUILD_SRC_DIR}/outdir:/work/indir" \
+    --volume="${AUTOMATION_BUILD_SRC_DIR}/stage:/work/indir" \
     codeontap/modelbender:latest \
     render --indir=indir
 
   mkdir -p "${AUTOMATION_BUILD_SRC_DIR}/dist"
   
-  cd "${AUTOMATION_BUILD_SRC_DIR}/outdir"
+  cd "${AUTOMATION_BUILD_SRC_DIR}/stage"
   zip -r "${AUTOMATION_BUILD_SRC_DIR}/dist/contentnode.zip" * 
 
   # All good


### PR DESCRIPTION
The render tasks renders the files in place rather than using the indir outdir approach. 

This updates the build job to reflect this. 