### PR TITLE
Python swagger

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -39,6 +39,12 @@ function save_product_infrastructure() {
   save_repo "${PRODUCT_INFRASTRUCTURE_DIR}" "infrastructure" "${arguments[@]}"
 }
 
+function save_product_code() {
+  local arguments=("$@")
+
+  save_repo "${AUTOMATION_BUILD_DIR}" "code" "${arguments[@]}"
+}
+
 # -- Context properties file --
 
 function save_context_property() {

--- a/jenkins/aws/buildPython.sh
+++ b/jenkins/aws/buildPython.sh
@@ -7,6 +7,9 @@ trap '[[ (-z "${AUTOMATION_DEBUG}") && (-d "${venv_dir}") ]] && rm -rf "${venv_d
 function main() {
   # Make sure we are in the build source directory
   cd ${AUTOMATION_BUILD_SRC_DIR}
+  
+  # Update git origin url for product code repo to specify automation user credentials for successful push
+  [[ -n "${PRODUCT_CODE_REPO}" ]] && git remote set-url origin https://${GITHUB_CREDENTIALS}@${GITHUB_GIT_DNS}/${GITHUB_GIT_ORG}/${PRODUCT_CODE_REPO}.git
 
   # Determine required tasks
   # test is always required

--- a/jenkins/aws/manageRepo.sh
+++ b/jenkins/aws/manageRepo.sh
@@ -149,8 +149,15 @@ function push() {
 
         trace "Pushing the ${REPO_LOG_NAME} repo upstream..."
         git push --tags ${REPO_REMOTE} ${REPO_BRANCH}
+        # If push failed HEAD might be detached. Create a temp branch and merge it to the target to fix it.
         RESULT=$? && [[ ${RESULT} -ne 0 ]] && \
-            fatal "Can't push the ${REPO_LOG_NAME} repo changes to upstream repo ${REPO_REMOTE}" && return 1
+            git branch temp-${REPO_BRANCH} && \
+            git checkout ${REPO_BRANCH} && \
+            git merge temp-${REPO_BRANCH} && \
+            git branch -D temp-${REPO_BRANCH} && \
+            git push --tags ${REPO_REMOTE} ${REPO_BRANCH} && \
+            RESULT=$? && [[ ${RESULT} -ne 0 ]] && \
+                fatal "Can't push the ${REPO_LOG_NAME} repo changes to upstream repo ${REPO_REMOTE}" && return 1
     fi
 }
 


### PR DESCRIPTION
These changes are required for successful swagger documents generation by `manage.py swagger` command.

In `common.sh` there is a new function to save product code repo. It is the same to the existing ones for config and infrastructure.

In `buildPython.sh` there are two changes:

1. Jenkins checkouts the code repo with https://github.com/{org}/{product-code-repo} style for git remote url. But we need the credentials to be specified in the url for push (we clone config and infrastructure this way). I'm not happy with variables I used, but `$PRODUCT_CODE_REPO` variable is specified only for this product so shall not affect others.

2. This project needs to iterate a list `$COMPONENT_INSTANCES` to produce three different documents. If this variable is not specified, a single `manage.py swagger` command will be triggered as expected.

In `manageRepo.sh` I had to add merge to the branch, as Jenkins checkouts code repo with detached HEAD. It is a retry to push the code.