### PR TITLE
Install Dev dependecies for meteor build

### DIFF
--- a/jenkins/aws/buildMeteor.sh
+++ b/jenkins/aws/buildMeteor.sh
@@ -11,7 +11,7 @@ cd app
 NODE_PACKAGE_MANAGER="${NODE_PACKAGE_MANAGER:-yarn}"
 
 # Install required node modules
-${NODE_PACKAGE_MANAGER} install --production
+${NODE_PACKAGE_MANAGER} install
 RESULT=$?
 [[ $RESULT -ne 0 ]] && fatal "npm install failed"
 


### PR DESCRIPTION
When a meteor build is performed the meteor build process requires some of the dev dependency packages, they aren't required for the bundled package though which just needs the production packages