### PR TITLE
Upgrade CMDB when creating the context tree

### DIFF
--- a/constructTree.sh
+++ b/constructTree.sh
@@ -332,6 +332,11 @@ fi
 findGen3Dirs "${BASE_DIR}"
 RESULT=$? && [[ ${RESULT} -ne 0 ]] && exit
 
+# Check the cmdb doesn't need upgrading
+debug "Checking if cmdb upgrade needed ..."
+upgrade_cmdb "${BASE_DIR}" ||
+    { RESULT=$?; fatal "CMDB upgrade failed."; exit }
+
 # Remember directories for future steps
 save_gen3_dirs_in_context
 

--- a/contextTree.sh
+++ b/contextTree.sh
@@ -606,7 +606,7 @@ function findGen3Dirs() {
       declare -gx ${prefix}ENVIRONMENT_SHARED_SETTINGS_DIR=$(getGen3Env   "PRODUCT_SETTINGS_DIR"   "${prefix}")/${environment}
       declare -gx ${prefix}ENVIRONMENT_SHARED_SOLUTIONS_DIR=$(getGen3Env  "PRODUCT_SOLUTIONS_DIR"  "${prefix}")/${environment}
       declare -gx ${prefix}ENVIRONMENT_SHARED_OPERATIONS_DIR=$(getGen3Env "PRODUCT_OPERATIONS_DIR" "${prefix}")/${environment}
-      debug "ENVIRONMENT_DIR=$(getGen3Env "PRODUCT_OPERATIONS_DIR" "${prefix}")/${environment}"
+      debug "ENVIRONMENT_DIR=$(getGen3Env "PRODUCT_SOLUTIONS_DIR" "${prefix}")/${environment}"
 
       if [[ -n "${segment}" ]]; then
 
@@ -618,7 +618,7 @@ function findGen3Dirs() {
         declare -gx ${prefix}SEGMENT_BUILDS_DIR=$(getGen3Env     "PRODUCT_SETTINGS_DIR"   "${prefix}")/${environment}/${segment}
         declare -gx ${prefix}SEGMENT_SOLUTIONS_DIR=$(getGen3Env  "PRODUCT_SOLUTIONS_DIR"  "${prefix}")/${environment}/${segment}
         declare -gx ${prefix}SEGMENT_OPERATIONS_DIR=$(getGen3Env "PRODUCT_OPERATIONS_DIR" "${prefix}")/${environment}/${segment}
-        debug "SEGMENT_DIR=$(getGen3Env "PRODUCT_OPERATIONS_DIR" "${prefix}")/${environment}/${segment}"
+        debug "SEGMENT_DIR=$(getGen3Env "PRODUCT_SOLUTIONS_DIR" "${prefix}")/${environment}/${segment}"
       fi
     fi
   fi


### PR DESCRIPTION
Ensure the CMDB is up to date before attempting anything else.