### PR TITLE
Correct bash syntax error

### DIFF
--- a/jenkins/aws/manageDocker.sh
+++ b/jenkins/aws/manageDocker.sh
@@ -249,7 +249,7 @@ defineDockerProviderAttributes "${REMOTE_DOCKER_PROVIDER}" "REMOTE_DOCKER_PROVID
 
 # pull = tag if local provider = remote provider
 if [[ ("${DOCKER_PROVIDER}" == "${REMOTE_DOCKER_PROVIDER}") &&
-        ("${DOCKER_OPERATION}" == "${${DOCKER_OPERATION_PULL}}") ]]; then
+        ("${DOCKER_OPERATION}" == "${DOCKER_OPERATION_PULL}") ]]; then
     DOCKER_OPERATION="${DOCKER_OPERATION_TAG}"
 fi
 

--- a/jenkins/aws/manageS3Registry.sh
+++ b/jenkins/aws/manageS3Registry.sh
@@ -280,7 +280,7 @@ defineRegistryProviderAttributes "${REMOTE_REGISTRY_PROVIDER}" "${REGISTRY_TYPE}
 
 # pull = tag if local provider = remote provider
 if [[ ("${REGISTRY_PROVIDER}" == "${REMOTE_REGISTRY_PROVIDER}") &&
-        ("${REGISTRY_OPERATION}" == "${${REGISTRY_OPERATION_PULL}}") ]]; then
+        ("${REGISTRY_OPERATION}" == "${REGISTRY_OPERATION_PULL}") ]]; then
     REGISTRY_OPERATION="${REGISTRY_OPERATION_TAG}"
 fi
 


### PR DESCRIPTION
This is a wierd one - not sure where this bug came from as git blame
doesn't show any change for over a year.

Most likely source is an error in rebasing for the 5.1.0 release.