### PR TITLE
add support for ENV_FILE in unit phase for python build

### DIFF
--- a/jenkins/aws/buildPython.sh
+++ b/jenkins/aws/buildPython.sh
@@ -84,7 +84,7 @@ function main() {
         MANAGE_OPTIONS+=" ${UNIT_OPTIONS}"
       fi
 
-      python manage.py test ${MANAGE_OPTIONS} ||
+      ENV_FILE=${PYTHON_UNIT_TEST_ENV_FILE} python manage.py test ${MANAGE_OPTIONS} ||
         { exit_status=$?; fatal "Tests failed"; return ${exit_status}; }
     else
       warning "No manage.py - no tests run"


### PR DESCRIPTION
We need an ability to define a default environment for unit tests, as sometimes it is preferable to have them defined. 
So instead of 
```
'SQLALCHEMY_DATABASE_URI': env('DATABASE_URL', default=None)
```
code makes 'SQLALCHEMY_DATABASE_URI' variable required to be defined:

```
'SQLALCHEMY_DATABASE_URI': env('DATABASE_URL')
```

Otherwise, the app will not start as improperly configured.
For unit tests, such required variables have dummy values, so the test can start. 
So basically this is just another place for a variable to be defined. 

The approach from this PR works for the cases when python attempts to read a file name for environ from a variable and if it is not set, uses a default value, which must be `.env` so it will be ignored by git and will not get into an image:

```
env_file_name = os.environ.get('ENV_FILE', '.env_base')
env_file = str(os.path.join(PROJECT_ROOT, env_file_name))
env.read_env(env_file)
```
This change will not affect a python application if it is not using 'ENV_FILE' but will help to define a minimum required environment when it is needed.