### PR TITLE
Fix namedef variable definition

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -56,7 +56,7 @@ function save_context_property() {
     local property_value="${value}"
   else
     if namedef_supported; then
-      local -n property_value="${value}"
+      local -n property_value="${name}"
     else
       eval "local property_value=\"\${${name}}\""
     fi


### PR DESCRIPTION
Minor fix to use the name of an empty context property instead of the value