### PR TITLE
Add docker stage directory for docker container support

### DIFF
--- a/jenkins/aws/buildContentModelBender.sh
+++ b/jenkins/aws/buildContentModelBender.sh
@@ -4,31 +4,37 @@
 trap '[[ (-z "${AUTOMATION_DEBUG}") ; exit 1' SIGHUP SIGINT SIGTERM
 . "${AUTOMATION_BASE_DIR}/common.sh"
 
+dockertmpdir="$(getTempDir "cota_docker_XXXX" "${DOCKER_STAGE_DIR}")"
+chmod a+rwx "${dockertmpdir}"
+
 function main() {
   # Make sure we are in the build source directory
   cd ${AUTOMATION_BUILD_SRC_DIR}
   
   # Create Build folders for Jenkins Permissions
   mkdir -p ${AUTOMATION_BUILD_SRC_DIR}/stage
-  chmod a+rwx ${AUTOMATION_BUILD_SRC_DIR}/stage
+  mkdir -p "${dockertmpdir}/indir"
+  mkdir -p "${dockertmpdir}/stage"
+
+  cp "${AUTOMATION_BUILD_SRC_DIR}" "${dockertmpdir}/indir"
 
   # run Model Bender build using Docker Build image 
   info "Running ModelBender enterprise tasks..."
   docker run --rm \
-    --volume="${AUTOMATION_BUILD_SRC_DIR}:/work/indir" \
-    --volume="${AUTOMATION_BUILD_SRC_DIR}/stage:/work/outdir" \
+    --volume="${dockertmpdir}/indir:/work/indir" \
+    --volume="${dockertmpdir}/stage:/work/outdir" \
     codeontap/modelbender:latest \
     enterprise --indir=indir --outdir=outdir
 
   info "Rendering ModelBender content..."
   docker run --rm \
-    --volume="${AUTOMATION_BUILD_SRC_DIR}/stage:/work/indir" \
+    --volume="${dockertmpdir}/stage:/work/indir" \
     codeontap/modelbender:latest \
     render --indir=indir
 
+  cd "${dockertmpdir}/stage"
+
   mkdir -p "${AUTOMATION_BUILD_SRC_DIR}/dist"
-  
-  cd "${AUTOMATION_BUILD_SRC_DIR}/stage"
   zip -r "${AUTOMATION_BUILD_SRC_DIR}/dist/contentnode.zip" * 
 
   # All good

--- a/jenkins/aws/buildContentModelBender.sh
+++ b/jenkins/aws/buildContentModelBender.sh
@@ -4,8 +4,8 @@
 trap '[[ (-z "${AUTOMATION_DEBUG}") ; exit 1' SIGHUP SIGINT SIGTERM
 . "${AUTOMATION_BASE_DIR}/common.sh"
 
-dockertmpdir="$(getTempDir "cota_docker_XXXX" "${DOCKER_STAGE_DIR}")"
-chmod a+rwx "${dockertmpdir}"
+dockerstagedir="$(getTempDir "cota_docker_XXXX" "${DOCKER_STAGE_DIR}")"
+chmod a+rwx "${dockerstagedir}"
 
 function main() {
   # Make sure we are in the build source directory
@@ -13,26 +13,26 @@ function main() {
   
   # Create Build folders for Jenkins Permissions
   mkdir -p ${AUTOMATION_BUILD_SRC_DIR}/stage
-  mkdir -p "${dockertmpdir}/indir"
-  mkdir -p "${dockertmpdir}/stage"
+  mkdir -p "${dockerstagedir}/indir"
+  mkdir -p "${dockerstagedir}/stage"
 
-  cp "${AUTOMATION_BUILD_SRC_DIR}" "${dockertmpdir}/indir"
+  cp "${AUTOMATION_BUILD_SRC_DIR}" "${dockerstagedir}/indir"
 
   # run Model Bender build using Docker Build image 
   info "Running ModelBender enterprise tasks..."
   docker run --rm \
-    --volume="${dockertmpdir}/indir:/work/indir" \
-    --volume="${dockertmpdir}/stage:/work/outdir" \
+    --volume="${dockerstagedir}/indir:/work/indir" \
+    --volume="${dockerstagedir}/stage:/work/outdir" \
     codeontap/modelbender:latest \
     enterprise --indir=indir --outdir=outdir
 
   info "Rendering ModelBender content..."
   docker run --rm \
-    --volume="${dockertmpdir}/stage:/work/indir" \
+    --volume="${dockerstagedir}/stage:/work/indir" \
     codeontap/modelbender:latest \
     render --indir=indir
 
-  cd "${dockertmpdir}/stage"
+  cd "${dockerstagedir}/stage"
 
   mkdir -p "${AUTOMATION_BUILD_SRC_DIR}/dist"
   zip -r "${AUTOMATION_BUILD_SRC_DIR}/dist/contentnode.zip" * 

--- a/jenkins/aws/buildInfraDocs.sh
+++ b/jenkins/aws/buildInfraDocs.sh
@@ -5,6 +5,8 @@ trap '[[ (-z "${AUTOMATION_DEBUG}") ; exit 1' SIGHUP SIGINT SIGTERM
 . "${AUTOMATION_BASE_DIR}/common.sh"
 
 tmpdir="$(getTempDir "cota_inf_XXX")"
+dockertmpdir="$(getTempDir "cota_docker_XXXX" "${DOCKER_STAGE_DIR}")"
+chmod a+rwx "${dockertmpdir}"
 
 function main() {
   # Make sure we are in the build source directory
@@ -38,19 +40,24 @@ function main() {
 
   # run Jekyll build using Docker Build image 
   info "Running Jeykyll build"
+
+  mkdir -p "${dockertmpdir}/indir"
+  mkdir -p "${dockertmpdir}/outdir"
+  cp ${AUTOMATION_BUILD_SRC_DIR} "${dockertmpdir}/indir"
+
   docker run --rm \
     --env JEKYLL_ENV="${JEKYLL_ENV}" \
     --env TZ="${JEKYLL_TIMEZONE}" \
-    --volume="${AUTOMATION_BUILD_SRC_DIR}:/indir" \
-    --volume="${tmpdir}/_site:/outdir" \
+    --volume="${dockertmpdir}/indir:/indir" \
+    --volume="${dockertmpdir}/outdir:/outdir" \
     codeontap/infradocs:"${INFRADOCS_VERSION}" 
 
   # Package for spa if required
   if [[ -f "${tmpdir}/_site/${JEKYLL_DEFAULT_PAGE}" ]]; then
     
+    cd "${dockertmpdir}/outdir"
+
     mkdir -p "${AUTOMATION_BUILD_SRC_DIR}/dist"
-    
-    cd "${tmpdir}/_site"
     zip -r "${AUTOMATION_BUILD_SRC_DIR}/dist/spa.zip" * 
     
   else 

--- a/jenkins/aws/buildInfraDocs.sh
+++ b/jenkins/aws/buildInfraDocs.sh
@@ -5,8 +5,8 @@ trap '[[ (-z "${AUTOMATION_DEBUG}") ; exit 1' SIGHUP SIGINT SIGTERM
 . "${AUTOMATION_BASE_DIR}/common.sh"
 
 tmpdir="$(getTempDir "cota_inf_XXX")"
-dockertmpdir="$(getTempDir "cota_docker_XXXX" "${DOCKER_STAGE_DIR}")"
-chmod a+rwx "${dockertmpdir}"
+dockerstagedir="$(getTempDir "cota_docker_XXXX" "${DOCKER_STAGE_DIR}")"
+chmod a+rwx "${dockerstagedir}"
 
 function main() {
   # Make sure we are in the build source directory
@@ -41,21 +41,21 @@ function main() {
   # run Jekyll build using Docker Build image 
   info "Running Jeykyll build"
 
-  mkdir -p "${dockertmpdir}/indir"
-  mkdir -p "${dockertmpdir}/outdir"
-  cp ${AUTOMATION_BUILD_SRC_DIR} "${dockertmpdir}/indir"
+  mkdir -p "${dockerstagedir}/indir"
+  mkdir -p "${dockerstagedir}/outdir"
+  cp ${AUTOMATION_BUILD_SRC_DIR} "${dockerstagedir}/indir"
 
   docker run --rm \
     --env JEKYLL_ENV="${JEKYLL_ENV}" \
     --env TZ="${JEKYLL_TIMEZONE}" \
-    --volume="${dockertmpdir}/indir:/indir" \
-    --volume="${dockertmpdir}/outdir:/outdir" \
+    --volume="${dockerstagedir}/indir:/indir" \
+    --volume="${dockerstagedir}/outdir:/outdir" \
     codeontap/infradocs:"${INFRADOCS_VERSION}" 
 
   # Package for spa if required
   if [[ -f "${tmpdir}/_site/${JEKYLL_DEFAULT_PAGE}" ]]; then
     
-    cd "${dockertmpdir}/outdir"
+    cd "${dockerstagedir}/outdir"
 
     mkdir -p "${AUTOMATION_BUILD_SRC_DIR}/dist"
     zip -r "${AUTOMATION_BUILD_SRC_DIR}/dist/spa.zip" * 

--- a/jenkins/aws/buildJekyll.sh
+++ b/jenkins/aws/buildJekyll.sh
@@ -4,8 +4,8 @@
 trap '[[ (-z "${AUTOMATION_DEBUG}") ; exit 1' SIGHUP SIGINT SIGTERM
 . "${AUTOMATION_BASE_DIR}/common.sh"
 
-dockertmpdir="$(getTempDir "cota_docker_XXXX" "${DOCKER_STAGE_DIR}")"
-chmod a+rwx "${dockertmpdir}"
+dockerstagedir="$(getTempDir "cota_docker_XXXX" "${DOCKER_STAGE_DIR}")"
+chmod a+rwx "${dockerstagedir}"
 
 function main() {
   # Make sure we are in the build source directory
@@ -35,23 +35,23 @@ function main() {
     JEKYLL_ENV="production"
   fi
 
-  mkdir "${dockertmpdir}/indir"
-  cp "${AUTOMATION_BUILD_SRC_DIR}"  "${dockertmpdir}/indir"
+  mkdir "${dockerstagedir}/indir"
+  cp "${AUTOMATION_BUILD_SRC_DIR}"  "${dockerstagedir}/indir"
 
   # run Jekyll build using Docker Build image 
   info "Running Jeykyll build"
   docker run --rm \
     --env JEKYLL_ENV="${JEKYLL_ENV}" \
     --env TZ="${JEKYLL_TIMEZONE}" \
-    --volume="${dockertmpdir}/indir:/srv/jekyll" \
+    --volume="${dockerstagedir}/indir:/srv/jekyll" \
     jekyll/builder:"${JEKYLL_VERSION}" \
     jekyll build --verbose 
     
   # Package for spa if required
-  if [[ -f "${dockertmpdir}/indir/_site/${JEKYLL_DEFAULT_PAGE}" ]]; then
+  if [[ -f "${dockerstagedir}/indir/_site/${JEKYLL_DEFAULT_PAGE}" ]]; then
 
     # Allow access to all files that have been generated so they can be cleaned up. 
-    cd "${dockertmpdir}/indir/_site"
+    cd "${dockerstagedir}/indir/_site"
     
     mkdir -p "${AUTOMATION_BUILD_SRC_DIR}/dist"
     zip -r "${AUTOMATION_BUILD_SRC_DIR}/dist/spa.zip" * 

--- a/jenkins/aws/buildSwagger.sh
+++ b/jenkins/aws/buildSwagger.sh
@@ -15,8 +15,8 @@ SWAGGER_RESULT_FILE="${DIST_DIR}/swagger.zip"
 tmpdir="$(getTempDir "cota_sw_XXX")"
 debug "TMPDIR=${tmpdir}"
 
-dockertmpdir="$(getTempDir "cota_docker_XXXX" "${DOCKER_STAGE_DIR}")"
-chmod a+rwx "${dockertmpdir}"
+dockerstagedir="$(getTempDir "cota_docker_XXXX" "${DOCKER_STAGE_DIR}")"
+chmod a+rwx "${dockerstagedir}"
 
 # Determine build dir in case of multiple specs in subdirs
 BUILD_DIR="$(fileName "${AUTOMATION_BUILD_DIR}" )"
@@ -44,20 +44,20 @@ SWAGGER_SPEC_YAML_EXTENSIONS_FILE=$(findFile \
                     "${AUTOMATION_BUILD_DEVOPS_DIR}/codeontap/swagger_extensions.yaml")
 
 # Make a local copy of the swagger json file
-TEMP_SWAGGER_SPEC_FILE="${dockertmpdir}/swagger.json"
+TEMP_SWAGGER_SPEC_FILE="${dockerstagedir}/swagger.json"
 [[ -f "${SWAGGER_SPEC_FILE}" ]] && cp "${SWAGGER_SPEC_FILE}" "${TEMP_SWAGGER_SPEC_FILE}"
 
 # Convert yaml files to json, possibly including a separate yaml based extensions file
-TEMP_SWAGGER_SPEC_YAML_FILE="${dockertmpdir}/swagger.yaml"
+TEMP_SWAGGER_SPEC_YAML_FILE="${dockerstagedir}/swagger.yaml"
 if [[ -f "${SWAGGER_SPEC_YAML_FILE}" ]]; then
     cp "${SWAGGER_SPEC_YAML_FILE}" "${TEMP_SWAGGER_SPEC_YAML_FILE}"
 
     if [[ -f "${SWAGGER_SPEC_YAML_EXTENSIONS_FILE}" ]]; then
         # Combine the two
-        cp "${TEMP_SWAGGER_SPEC_YAML_FILE}" "${dockertmpdir}/swagger_copy.yaml"
-        cp "${SWAGGER_SPEC_YAML_EXTENSIONS_FILE}" "${dockertmpdir}/swagger_extensions.yaml"
+        cp "${TEMP_SWAGGER_SPEC_YAML_FILE}" "${dockerstagedir}/swagger_copy.yaml"
+        cp "${SWAGGER_SPEC_YAML_EXTENSIONS_FILE}" "${dockerstagedir}/swagger_extensions.yaml"
         docker run --rm \
-            -v "${dockertmpdir}:/app/indir" -v "${dockertmpdir}:/app/outdir" \
+            -v "${dockerstagedir}:/app/indir" -v "${dockerstagedir}:/app/outdir" \
             codeontap/utilities sme merge \
             /app/indir/swagger_copy.yaml \
             /app/indir/swagger_extensions.yaml \
@@ -68,7 +68,7 @@ if [[ -f "${SWAGGER_SPEC_YAML_FILE}" ]]; then
     # AWS uses these are directives in API Gateway templates
     COMBINE_COMMAND="import sys, yaml, json; json.dump(yaml.load(open('/app/indir/$(fileName ${TEMP_SWAGGER_SPEC_YAML_FILE})','r')), open('/app/outdir/$(fileName ${TEMP_SWAGGER_SPEC_FILE})','w'), indent=4)"
     docker run --rm \
-        -v "${dockertmpdir}:/app/indir" -v "${dockertmpdir}:/app/outdir" \
+        -v "${dockerstagedir}:/app/indir" -v "${dockerstagedir}:/app/outdir" \
         codeontap/python-utilities \
         -c "${COMBINE_COMMAND}"
 fi
@@ -82,7 +82,7 @@ VALIDATORS=( \
 "swagger-tools validate /app/indir/$(fileName ${TEMP_SWAGGER_SPEC_FILE})" \
 "ajv           validate -d /app/indir/$(fileName ${TEMP_SWAGGER_SPEC_FILE}) -s /usr/local/lib/node_modules/swagger-schema-official/schema.json")
 for VALIDATOR in "${VALIDATORS[@]}"; do
-    docker run --rm -v "${dockertmpdir}:/app/indir" codeontap/utilities ${VALIDATOR} ||
+    docker run --rm -v "${dockerstagedir}:/app/indir" codeontap/utilities ${VALIDATOR} ||
       { exit_status=$?; fatal "Swagger file is not valid"; exit ${exit_status}; }
 done
 
@@ -114,18 +114,18 @@ else
 fi
 
 # Generate documentation
-mkdir "${dockertmpdir}/swaggerUI/indir"
-mkdir "${dockertmpdir}/swaggerUI/outdir"
+mkdir "${dockerstagedir}/swaggerUI/indir"
+mkdir "${dockerstagedir}/swaggerUI/outdir"
 
 [[ -f "${TEMP_SWAGGER_SPEC_FILE}" ]] && 
-    cp "${TEMP_SWAGGER_SPEC_FILE}" "${dockertmpdir}/swaggerUI/indir"
+    cp "${TEMP_SWAGGER_SPEC_FILE}" "${dockerstagedir}/swaggerUI/indir"
 
 docker run --rm \
-    -v "${dockertmpdir}/swaggerUI/indir:/app/indir" -v "${dockertmpdir}/swaggerUI/outdir:/app/outdir" \
+    -v "${dockerstagedir}/swaggerUI/indir:/app/indir" -v "${dockerstagedir}/swaggerUI/outdir:/app/outdir" \
     -e SWAGGER_JSON=/app/indir/$(fileName "${TEMP_SWAGGER_SPEC_FILE}") \
     codeontap/swaggerui-export
 
-cp "${dockertmpdir}/swaggerUI/outdir" "${DIST_DIR}"
+cp "${dockerstagedir}/swaggerUI/outdir" "${DIST_DIR}"
 
 RESULT=$?
 [[ "${RESULT}" -ne 0 ]] && fatal "Swagger file documentation generation failed" && exit 1


### PR DESCRIPTION
With the move to docker images for codeontap we need to be able to run docker images from within a container.  The easiest approach for this is to mount the host docker socket into the container. However do this means that when you mount a volume to the container it needs to be accessible to both the host container and the host system. 

This PR moves all docker volume mount points to a dedicated directory for this purpose, dockerstagedir. For each process each dockerstagedir is a unique directory (using mktemp) 

You can specify the location (a mounted data volume, or external data share) that will be mounted in the same location on the host and the container host. 

The default is to use the OSTempDir (/tmp) and the Env Variable DOCKER_STAGE_DIR controls the directory the stage will be created in.