### PR TITLE
Disable validation for swaggerUI

### DIFF
--- a/jenkins/aws/buildSwagger.sh
+++ b/jenkins/aws/buildSwagger.sh
@@ -123,7 +123,8 @@ mkdir -p "${dockerstagedir}/swaggerUI/outdir"
 SWAGGER_SPEC_TITLE="$(jq -r '.info.title' <  "${TEMP_SWAGGER_SPEC_FILE}")"
 docker run --rm \
     -v "${dockerstagedir}/swaggerUI/indir:/app/indir" -v "${dockerstagedir}/swaggerUI/outdir:/app/outdir" \
-    -e API_URLS="[{\"url\": \"/swagger.json\", \"name\" : \"${SWAGGER_SPEC_TITLE}\"}]" \
+    -e API_URLS="[{\"url\": \"./swagger.json\", \"name\" : \"${SWAGGER_SPEC_TITLE}\"}]" \
+    -e VALIDATOR_URL="null" \
     codeontap/swaggerui-export
 
 cp -r "${dockerstagedir}"/swaggerUI/outdir/* "${DIST_DIR}/"


### PR DESCRIPTION
By default the swaggerui container will try and validate the swagger URL against the swaggerhub public service. For locked down environments this doesn't work and you get an error that it didn't work. 

Along with that we already validate swagger specs so not much of a point in doing it when we publish the spec.