### PR TITLE
fix path to test results and add coverage support

### DIFF
--- a/jenkins/aws/buildPython.sh
+++ b/jenkins/aws/buildPython.sh
@@ -84,8 +84,12 @@ function main() {
         MANAGE_OPTIONS=" --junitxml=${MANAGE_OPTIONS}"
       fi
       if [[ -n ${COVERAGE_REPORT} ]]; then
+        # Note: coverage and pytest-cov are required to run `pytest` with `--cov` option
+        # COVERAGE_REPORT specifies output format - xml, html or annotate
         MANAGE_OPTIONS+=" --cov --cov-report ${COVERAGE_REPORT}"
         if [[ -n ${COVERAGE_REPORT_OUTPUT} ]]; then
+          # COVERAGE_REPORT_OUTPUT specifies output path
+          # see https://pypi.org/project/pytest-cov/ for details
           MANAGE_OPTIONS+=":${COVERAGE_REPORT_OUTPUT}"
         fi
       fi

--- a/jenkins/aws/buildPython.sh
+++ b/jenkins/aws/buildPython.sh
@@ -81,7 +81,13 @@ function main() {
       info "Running unit tests with pytest..."
       if [[ -n ${MANAGE_OPTIONS} ]]; then
         # Set --junitxml option if TEST_REPORTS_DIR and TEST_JUNIT_DIR are set
-        MANAGE_OPTIONS=" --junitxml="+"${MANAGE_OPTIONS}"
+        MANAGE_OPTIONS=" --junitxml=${MANAGE_OPTIONS}"
+      fi
+      if [[ -n ${COVERAGE_REPORT} ]]; then
+        MANAGE_OPTIONS+=" --cov --cov-report ${COVERAGE_REPORT}"
+        if [[ -n ${COVERAGE_REPORT_OUTPUT} ]]; then
+          MANAGE_OPTIONS+=":${COVERAGE_REPORT_OUTPUT}"
+        fi
       fi
       if [[ -n ${UNIT_OPTIONS} ]]; then
         MANAGE_OPTIONS+=" ${UNIT_OPTIONS}"
@@ -93,7 +99,7 @@ function main() {
         info "Running unit tests with manage.py test..."
         if [[ -n ${MANAGE_OPTIONS} ]]; then
           # Set --junit-xml argument if TEST_REPORTS_DIR and TEST_JUNIT_DIR are set
-          MANAGE_OPTIONS=" --junit-xml "+"${MANAGE_OPTIONS}"
+          MANAGE_OPTIONS=" --junit-xml ${MANAGE_OPTIONS}"
         fi
         if [[ -n ${UNIT_OPTIONS} ]]; then
           MANAGE_OPTIONS+=" ${UNIT_OPTIONS}"


### PR DESCRIPTION
The path for test results gets an "+" - fixed that.
Also added a support for coverage, `COVERAGE_REPORT` and `COVERAGE_REPORT_OUTPUT` to control it. 