### PR TITLE
Add Data pipeline build support

### DIFF
--- a/jenkins/aws/buildPipeline.sh
+++ b/jenkins/aws/buildPipeline.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+[[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
+trap '[[ (-z "${AUTOMATION_DEBUG}") ; exit 1' SIGHUP SIGINT SIGTERM
+. "${AUTOMATION_BASE_DIR}/common.sh"
+
+tmpdir="$(getTempDir "cota_inf_XXX")"
+
+function main() {
+    # Make sure we are in the build source directory
+    cd ${AUTOMATION_BUILD_SRC_DIR}
+    
+    # Make sure we have a script to start from
+    [[ ! -f pipeline-definition.json   ]] &&
+        { fatal "No pipeline-definition.json found"; return 1; }
+
+    cp pipeline-definition.json "${tmpdir}/pipeline-definition.json"
+    
+    if [[ -f pipeline-parameters.json ]]; then
+        cp pipeline-parameters.json "${tmpdir}/pipeline-parameters.json"
+    else
+        echo "{}" > "${tmpdir}/pipeline-definition.json"
+    fi
+
+    mkdir "${tmpdir}/_scripts"
+
+    for item in *; do
+        if [ -d ${item} ]; then
+            cd {$item}
+            zip -r "${tmpdir}/_scripts/${item}.zip" *
+            cd ${AUTOMATION_BUILD_SRC_DIR}
+        fi
+    done
+
+    cd "${tmpdir}"
+    zip -r "${tmpdir}/pipeline.zip" *  
+
+    if [[ -f ${tmpdir}/pipeline.zip ]]; then
+        mkdir "${AUTOMATION_BUILD_SRC_DIR}/dist"
+        cp ${tmpdir}/pipeline.zip "${AUTOMATION_BUILD_SRC_DIR}/dist/pipeline.zip"
+    fi
+
+    # All good
+    return 0
+}
+
+main "$@"

--- a/jenkins/aws/manageImages.sh
+++ b/jenkins/aws/manageImages.sh
@@ -105,7 +105,7 @@ for FORMAT in "${FORMATS[@]}"; do
             fi
             ;;
 
-        scripts) 
+        pipeline) 
             IMAGE_FILE="${AUTOMATION_BUILD_SRC_DIR}/dist/pipeline.zip"
             
             if [[ -f "${IMAGE_FILE}" ]]; then

--- a/jenkins/aws/manageImages.sh
+++ b/jenkins/aws/manageImages.sh
@@ -106,6 +106,20 @@ for FORMAT in "${FORMATS[@]}"; do
             ;;
 
         scripts) 
+            IMAGE_FILE="${AUTOMATION_BUILD_SRC_DIR}/dist/pipeline.zip"
+            
+            if [[ -f "${IMAGE_FILE}" ]]; then
+                ${AUTOMATION_DIR}/managePipeline.sh -s \
+                        -u "${DEPLOYMENT_UNIT}" \
+                        -g "${CODE_COMMIT}" \
+                        -f "${IMAGE_FILE}"
+                RESULT=$? && [[ "${RESULT}" -ne 0 ]]&& exit
+            else
+                RESULT=1 && fatal "${IMAGE_FILE} missing" && exit
+            fi
+            ;;
+
+        scripts) 
             IMAGE_FILE="${AUTOMATION_BUILD_SRC_DIR}/dist/scripts.zip"
             
             if [[ -f "${IMAGE_FILE}" ]]; then

--- a/jenkins/aws/managePipeline.sh
+++ b/jenkins/aws/managePipeline.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+[[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
+trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
+
+# Note that filename can still overridden via provided parameters
+${AUTOMATION_DIR}/manageS3Registry.sh -y "pipeline" -f "pipeline.zip" "$@"
+RESULT=$?
+

--- a/setContext.sh
+++ b/setContext.sh
@@ -156,7 +156,7 @@ function defineGitProviderSettings() {
         "API_DNS" "${DGPD_PROVIDER}" "${DGPD_PROVIDER_TYPE}" "value" "api.${NAME_VALUE}"
 }
 
-REGISTRY_TYPES=("docker" "lambda" "scripts" "swagger" "spa" "contentnode" )
+REGISTRY_TYPES=("docker" "lambda" "pipeline" "scripts" "swagger" "spa" "contentnode" )
 REGISTRY_PROVIDERS=()
 function defineRegistryProviderSettings() {
     # Define key values about use of a docker provider


### PR DESCRIPTION
Builds a data pipeline code artefact that works with https://github.com/codeontap/gen3/pull/434 

 It assumes the code repo has the layout 
```
<root>
   - pipeline-definition.json - the JSON based pipeline definition ( https://docs.aws.amazon.com/datapipeline/latest/DeveloperGuide/dp-writing-pipeline-definition.html ) 
   - pipeline-parameter.json - the JSON paramter definition file 
   - <ShellScriptName> 
            - init.sh - initial shell script that will be run as part of a ShellScript task in the pipeline
             - any other supporting scripts that init.sh might need to call 
``` 