### PR TITLE
add yarn support for python builds

### DIFF
--- a/jenkins/aws/buildPython.sh
+++ b/jenkins/aws/buildPython.sh
@@ -59,16 +59,11 @@ function main() {
     if [[ -f package.json ]]; then
       # Select the package manage to use
         if [[ -z "${NODE_PACKAGE_MANAGER}" ]]; then
-            if $(which yarn > /dev/null 2>&1) ; then
-                NODE_PACKAGE_MANAGER="yarn"
-            else
-                NODE_PACKAGE_MANAGER="npm"
-                NODE_PACKAGE_MANAGER_INSTALL_OPTIONS="--unsafe-perm"
-            fi
+            NODE_PACKAGE_MANAGER="npm"
         fi
         # Set install options
         case ${NODE_PACKAGE_MANAGER} in
-          nmp)
+          npm)
             NODE_PACKAGE_MANAGER_INSTALL_OPTIONS="--unsafe-perm"
             ;;
           *)

--- a/jenkins/aws/buildPython.sh
+++ b/jenkins/aws/buildPython.sh
@@ -57,8 +57,26 @@ function main() {
     fi
 
     if [[ -f package.json ]]; then
-      npm install --unsafe-perm ||
-        { exit_status=$?; fatal "npm install failed"; return ${exit_status}; }
+      # Select the package manage to use
+        if [[ -z "${NODE_PACKAGE_MANAGER}" ]]; then
+            if $(which yarn > /dev/null 2>&1) ; then
+                NODE_PACKAGE_MANAGER="yarn"
+            else
+                NODE_PACKAGE_MANAGER="npm"
+                NODE_PACKAGE_MANAGER_INSTALL_OPTIONS="--unsafe-perm"
+            fi
+        fi
+        # Set install options
+        case ${NODE_PACKAGE_MANAGER} in
+          nmp)
+            NODE_PACKAGE_MANAGER_INSTALL_OPTIONS="--unsafe-perm"
+            ;;
+          *)
+            NODE_PACKAGE_MANAGER_INSTALL_OPTIONS=""
+            ;;
+        esac
+        ${NODE_PACKAGE_MANAGER} install ${NODE_PACKAGE_MANAGER_INSTALL_OPTIONS} ||
+        { exit_status=$?; fatal "${NODE_PACKAGE_MANAGER} install failed"; return ${exit_status}; }
     fi
 
     # Run bower as part of the build if required
@@ -177,8 +195,16 @@ function main() {
   if inArray "REQUIRED_TASKS" "build|unit|swagger"; then
     # Clean up
     if [[ -f package.json ]]; then
-      npm prune --production ||
+      case ${NODE_PACKAGE_MANAGER} in
+        yarn)
+          yarn install --production ||
+        { exit_status=$?; fatal "yarn install --production failed"; return ${exit_status}; }
+          ;;
+        *)
+          npm prune --production ||
         { exit_status=$?; fatal "npm prune failed"; return ${exit_status}; }
+          ;;
+      esac
     fi
 
     # Clean up the virtual env


### PR DESCRIPTION
This change allows running yarn as a node package manager for python builds if it is installed and `NODE_PACKAGE_MANAGER` is not set to `npm` explicitly.