### PR TITLE
Add cleanup of pyc files that might have been created during testing

### DIFF
--- a/jenkins/aws/buildPython.sh
+++ b/jenkins/aws/buildPython.sh
@@ -159,6 +159,9 @@ function main() {
   fi
 
   if inArray "REQUIRED_TASKS" "build"; then
+    # Clean up pyc files before packagng into zappa 
+    find "${AUTOMATION_BUILD_SRC_DIR}" -name "*.pyc" -delete
+
     # Package for lambda if required
     for ZAPPA_DIR in "${AUTOMATION_BUILD_DEVOPS_DIR}/lambda" "./"; do
       if [[ -f "${ZAPPA_DIR}/zappa_settings.json" ]]; then

--- a/jenkins/aws/buildPython.sh
+++ b/jenkins/aws/buildPython.sh
@@ -159,7 +159,7 @@ function main() {
   fi
 
   if inArray "REQUIRED_TASKS" "build"; then
-    # Clean up pyc files before packagng into zappa 
+    # Clean up pyc files before packaging into zappa 
     find "${AUTOMATION_BUILD_SRC_DIR}" -name "*.pyc" -delete
 
     # Package for lambda if required


### PR DESCRIPTION
We have found some issues with pyc files that are created during integration and unit testing. We need to remove these as they can cause issues with the different version of python used for lambda