### PR TITLE
exit with actual exit code to fail a build

### DIFF
--- a/jenkins/aws/runTasks.sh
+++ b/jenkins/aws/runTasks.sh
@@ -25,7 +25,7 @@ for CURRENT_TASK in $TASK_LIST; do
     ${GENERATION_DIR}/runTask.sh -t "${TASK_TIER}" -i "${TASK_COMPONENT}" -w "${CURRENT_TASK}" -x "${TASK_INSTANCE}" -y "${TASK_VERSION}" -c "${TASK_CONTAINER}" "${ENVS[@]}"
     RESULT=$?
     [[ ${RESULT} -ne 0 ]] &&
-        fatal "Running of task ${CURRENT_TASK} failed" && exit
+        fatal "Running of task ${CURRENT_TASK} failed" && exit $RESULT
 done
 
 # All good


### PR DESCRIPTION
If task execution fails, exit code shall be returned, otherwise, a build is reported as successful.