### PR TITLE
Missing code repo config is now fatal

### DIFF
--- a/jenkins/aws/manageBuildReferences.sh
+++ b/jenkins/aws/manageBuildReferences.sh
@@ -388,8 +388,7 @@ for ((INDEX=0; INDEX<${#DEPLOYMENT_UNIT_ARRAY[@]}; INDEX++)); do
                     fi
                     if [[ ("${CODE_REPO}" == "?") ||
                             ("${CODE_PROVIDER}" == "?") ]]; then
-                        warning "Ignoring tag for the \"${CURRENT_DEPLOYMENT_UNIT}\" deployment unit - no code repo and/or provider defined"
-                        continue
+                        fatal "Ignoring tag for the \"${CURRENT_DEPLOYMENT_UNIT}\" deployment unit - no code repo and/or provider defined" && exit
                     fi
                     # Determine the details of the provider hosting the code repo
                     defineGitProviderAttributes "${CODE_PROVIDER}" "CODE"


### PR DESCRIPTION
If left a warning, the message is buried in the console log and any associated prepare seems to succeed, but the associated code reference isn't updated. Better to flag the error so the configuration issue can be addressed.