### PR TITLE
Drive prepare/deploy from DEPLOYMENT_UNIT_LIST

### DIFF
--- a/jenkins/aws/deploy.sh
+++ b/jenkins/aws/deploy.sh
@@ -5,6 +5,6 @@ trap 'exit 1' SIGHUP SIGINT SIGTERM
 . "${AUTOMATION_BASE_DIR}/common.sh"
 
 # Create the templates
-${AUTOMATION_DIR}/manageUnits.sh -l "application" -a "${DEPLOYMENT_UNITS}" -r "${PRODUCT_CONFIG_COMMIT}"
+${AUTOMATION_DIR}/manageUnits.sh -l "application" -a "${DEPLOYMENT_UNIT_LIST}" -r "${PRODUCT_CONFIG_COMMIT}"
 
 

--- a/jenkins/aws/deployRelease.sh
+++ b/jenkins/aws/deployRelease.sh
@@ -6,7 +6,7 @@ trap 'exit 1' SIGHUP SIGINT SIGTERM
 
 function main() {
   # Update the stacks
-  ${AUTOMATION_DIR}/manageUnits.sh -l "application" -a "${DEPLOYMENT_UNITS}" || return $?
+  ${AUTOMATION_DIR}/manageUnits.sh -l "application" -a "${DEPLOYMENT_UNIT_LIST}" || return $?
 
   # Add release and deployment tags to details
   DETAIL_MESSAGE="deployment=${DEPLOYMENT_TAG}, release=${RELEASE_TAG}, ${DETAIL_MESSAGE}"

--- a/jenkins/aws/prepareRelease.sh
+++ b/jenkins/aws/prepareRelease.sh
@@ -9,7 +9,7 @@ function main() {
   ${AUTOMATION_DIR}/manageBuildReferences.sh -u || return $?
   
   # Create the templates
-  ${AUTOMATION_DIR}/manageUnits.sh -l "application" -a "${DEPLOYMENT_UNITS}" -r "${RELEASE_TAG}" || return $?
+${AUTOMATION_DIR}/manageUnits.sh -l "application" -a "${DEPLOYMENT_UNIT_LIST}" -r "${RELEASE_TAG}" || return $?
   
   # All ok so tag the config repo
   save_product_config "${DETAIL_MESSAGE}" "${PRODUCT_CONFIG_REFERENCE}" "${RELEASE_TAG}" || return $?

--- a/setContext.sh
+++ b/setContext.sh
@@ -543,7 +543,7 @@ function main() {
   save_context_property CODE_REPO_LIST       "${CODE_REPO_ARRAY[*]}"
   save_context_property CODE_PROVIDER_LIST   "${CODE_PROVIDER_ARRAY[*]}"
   save_context_property IMAGE_FORMATS_LIST   "${IMAGE_FORMATS_ARRAY[*]}"
-  [[ -n "${UPDATED_UNITS}" ]] && save_context_property DEPLOYMENT_UNITS "${UPDATED_UNITS}"
+  [[ -n "${UPDATED_UNITS}" ]] && save_context_property CLEANED_DEPLOYMENT_UNITS "${UPDATED_UNITS}"
 
   ### Release management ###
 


### PR DESCRIPTION
DEPLOYMENT_UNITS is reserved as the parameter defined in the job
definition. It needs to be cleaned to remove things like blank lines in
the case of multi-line input.

Therefore it should never be used directly. Either the individual arrays
like DEPLOYMENT_UNIT_LIST, or CLEANED_DEPLOYMENT_UNITS should be used.