### PR TITLE
Allow for Build Src Dir override

### DIFF
--- a/setContext.sh
+++ b/setContext.sh
@@ -300,14 +300,21 @@ function main() {
 
       # Build source directory
       AUTOMATION_BUILD_SRC_DIR="${AUTOMATION_BUILD_DIR}"
-      [[ -d "${AUTOMATION_BUILD_DIR}/src" ]] &&
-        AUTOMATION_BUILD_SRC_DIR="${AUTOMATION_BUILD_DIR}/src"
 
-      [[ -d "${AUTOMATION_BUILD_DIR}/app" ]] &&
-        AUTOMATION_BUILD_SRC_DIR="${AUTOMATION_BUILD_DIR}/app"
+      if [[ -n "${BUILD_SRC_DIR}" ]]; then 
+        [[ -d "${AUTOMATION_BUILD_DIR}/${BUILD_SRC_DIR}" ]] && 
+            AUTOMATION_BUILD_SRC_DIR="${AUTOMATION_BUILD_DIR}/${BUILD_SRC_DIR}" ||
+            { fatal "Build source directory ${BUILD_SRC_DIR} not found"; exit; }
+      else
+        [[ -d "${AUTOMATION_BUILD_DIR}/src" ]] &&
+            AUTOMATION_BUILD_SRC_DIR="${AUTOMATION_BUILD_DIR}/src"
 
-      [[ -d "${AUTOMATION_BUILD_DIR}/content" ]] &&
-        AUTOMATION_BUILD_SRC_DIR="${AUTOMATION_BUILD_DIR}/content"
+        [[ -d "${AUTOMATION_BUILD_DIR}/app" ]] &&
+            AUTOMATION_BUILD_SRC_DIR="${AUTOMATION_BUILD_DIR}/app"
+
+        [[ -d "${AUTOMATION_BUILD_DIR}/content" ]] &&
+            AUTOMATION_BUILD_SRC_DIR="${AUTOMATION_BUILD_DIR}/content"
+      fi
 
       # Build devops directory
       AUTOMATION_BUILD_DEVOPS_DIR="${AUTOMATION_BUILD_DIR}"


### PR DESCRIPTION
Allow for the Build source directory to be overridden/explicitly defined. 

At the moment we try and find the source directory and then use the root of the directory. This allows for it to be defined using the variable BUILD_SRC_DIR which should be a directory within the BUILD_PATH 