### PR TITLE
Add support for removing the data staged in s3 dataset master

### DIFF
--- a/contextTree.sh
+++ b/contextTree.sh
@@ -337,6 +337,32 @@ function assemble_settings() {
   return ${return_status}
 }
 
+function assemble_composite_definitions() {
+
+  local tmp_file="$( getTempFile "definitions_XXXX" "${tmp_dir}" )"
+
+  # Gather the relevant definitions
+  local restore_nullglob=$(shopt -p nullglob)
+  shopt -s nullglob
+
+  local definitions_array=()
+  [[ (-n "${ACCOUNT}") ]] &&
+      addToArray "definitions_array" "${ACCOUNT_INFRASTRUCTURE_DIR}"/cf/shared/defn*-definition.json
+  [[ (-n "${PRODUCT}") && (-n "${REGION}") ]] &&
+      addToArray "definitions_array" "${PRODUCT_INFRASTRUCTURE_DIR}"/cf/shared/defn*-"${REGION}"*-definition.json
+  [[ (-n "${ENVIRONMENT}") && (-n "${SEGMENT}") && (-n "${REGION}") ]] &&
+      addToArray "definitions_array" "${PRODUCT_INFRASTRUCTURE_DIR}/cf/${ENVIRONMENT}/${SEGMENT}"/*-definition.json
+
+  ${restore_nullglob}
+
+  debug "DEFINITIONS=${definitions_array[*]}"
+  jqMerge "${definitions_array[@]}" > "${tmp_file}"
+
+  # Escape any freemarker markup
+  export COMPOSITE_DEFINITIONS="${CACHE_DIR}/composite_definitions.json"
+  sed 's/${/$\\{/g' < "${tmp_file}" > "${COMPOSITE_DEFINITIONS}"
+}
+
 function assemble_composite_stack_outputs() {
 
   # Create the composite stack outputs

--- a/jenkins/aws/buildDataSetS3.sh
+++ b/jenkins/aws/buildDataSetS3.sh
@@ -33,7 +33,7 @@ function main() {
             info "Master Data: ${dataset_master_location} "
             aws --region "${dataset_region}" s3api list-objects-v2 --bucket "${master_data_bucket_name}" --prefix "${dataset_prefix}" --query 'Contents[*].{Key:Key,ETag:ETag,LastModified:LastModified}' > "${data_manifest_file}" 
 
-            if [[ -f "${data_manifest_file}" ]]; then 
+            if [[ -f "${data_manifest_file}" && "$(cat ${data_manifest_file})" != "null"  ]]; then 
 
                 build_reference="$( shasum -U -a 1 "${data_manifest_file}" | cut -d " " -f 1  )"
                 save_context_property CODE_COMMIT_LIST "${build_reference}"
@@ -46,7 +46,7 @@ function main() {
                 info "Commit: ${build_reference}"
             
             else 
-                fatal "Could not generate data manifest file"
+                fatal "Could not generate data manifest file or no files could be found"
                 return 128
             fi 
                 

--- a/jenkins/aws/manageS3Registry.sh
+++ b/jenkins/aws/manageS3Registry.sh
@@ -273,7 +273,7 @@ function removeSource() {
         aws --region "${REGISTRY_PROVIDER_REGION}" s3 ls "${FILE_TO_REMOVE}"  >/dev/null 2>&1
         RESULT=$?
         [[ "$RESULT" -ne 0 ]] &&
-            fatal "Can't access ${FILE_TO_REMOVE}" && exit
+            fatal "Can't access ${FILE_TO_REMOVE}" && return 128
 
         aws --region "${REGISTRY_PROVIDER_REGION}" s3 rm --recursive "${FILE_TO_REMOVE}" 
     


### PR DESCRIPTION
Adds a new option to registry management `REGISTRY_REMOVE_SOURCE` which will remove the data from the master staging location once it has been copied up to the registry. 

This can be used for data drop releases which have unique data sets on each release so data that was added before should not be kept for the next data upload. 

This is disabled by default  