### PR TITLE
Fix bash locator

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Automation framework common definitions
 #

--- a/constructTree.sh
+++ b/constructTree.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM

--- a/jenkins/aws/acceptRelease.sh
+++ b/jenkins/aws/acceptRelease.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM

--- a/jenkins/aws/acceptReleaseSetup.sh
+++ b/jenkins/aws/acceptReleaseSetup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM

--- a/jenkins/aws/backup.sh
+++ b/jenkins/aws/backup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM

--- a/jenkins/aws/buildContentModelBender.sh
+++ b/jenkins/aws/buildContentModelBender.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 trap '[[ (-z "${AUTOMATION_DEBUG}") ; exit 1' SIGHUP SIGINT SIGTERM

--- a/jenkins/aws/buildContentStatic.sh
+++ b/jenkins/aws/buildContentStatic.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 trap '[[ (-z "${AUTOMATION_DEBUG}") ; exit 1' SIGHUP SIGINT SIGTERM

--- a/jenkins/aws/buildInfraDocs.sh
+++ b/jenkins/aws/buildInfraDocs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 trap '[[ (-z "${AUTOMATION_DEBUG}") ; exit 1' SIGHUP SIGINT SIGTERM

--- a/jenkins/aws/buildJS.sh
+++ b/jenkins/aws/buildJS.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 trap '[[ (-z "${AUTOMATION_DEBUG}") && (-d "${NVM_DIR}") ]] && nvm deactivate; rm -rf "${NVM_DIR}" ; exit $?' SIGHUP SIGINT SIGTERM
 . "${AUTOMATION_BASE_DIR}/common.sh"

--- a/jenkins/aws/buildJekyll.sh
+++ b/jenkins/aws/buildJekyll.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 trap '[[ (-z "${AUTOMATION_DEBUG}") ; exit 1' SIGHUP SIGINT SIGTERM

--- a/jenkins/aws/buildLaravel.sh
+++ b/jenkins/aws/buildLaravel.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM

--- a/jenkins/aws/buildMeteor.sh
+++ b/jenkins/aws/buildMeteor.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM

--- a/jenkins/aws/buildNode.sh
+++ b/jenkins/aws/buildNode.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM

--- a/jenkins/aws/buildPipeline.sh
+++ b/jenkins/aws/buildPipeline.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 trap '[[ (-z "${AUTOMATION_DEBUG}") ; exit 1' SIGHUP SIGINT SIGTERM

--- a/jenkins/aws/buildPlay.sh
+++ b/jenkins/aws/buildPlay.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/usr/bin/env bash -x
 
 # This script needs work - the content below was just captured here as a starting point
 # It is based on  a very old codeontap setup

--- a/jenkins/aws/buildPython.sh
+++ b/jenkins/aws/buildPython.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 trap '[[ (-z "${AUTOMATION_DEBUG}") && (-d "${venv_dir}") ]] && rm -rf "${venv_dir}"; exit 1' SIGHUP SIGINT SIGTERM

--- a/jenkins/aws/buildSPAStatic.sh
+++ b/jenkins/aws/buildSPAStatic.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # - Basic build for an SPA that is static content
 
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}

--- a/jenkins/aws/buildScripts.sh
+++ b/jenkins/aws/buildScripts.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 trap '[[ (-z "${AUTOMATION_DEBUG}") ; exit 1' SIGHUP SIGINT SIGTERM

--- a/jenkins/aws/buildSetup.sh
+++ b/jenkins/aws/buildSetup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM

--- a/jenkins/aws/buildSwagger.sh
+++ b/jenkins/aws/buildSwagger.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Augment a swagger file with AWS API gateway integration semantics
  

--- a/jenkins/aws/buildTenantBlueprints.sh
+++ b/jenkins/aws/buildTenantBlueprints.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 trap '[[ (-z "${AUTOMATION_DEBUG}") ; exit 1' SIGHUP SIGINT SIGTERM

--- a/jenkins/aws/confirmBuilds.sh
+++ b/jenkins/aws/confirmBuilds.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM

--- a/jenkins/aws/constructTree.sh
+++ b/jenkins/aws/constructTree.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM

--- a/jenkins/aws/deploy.sh
+++ b/jenkins/aws/deploy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 trap 'exit 1' SIGHUP SIGINT SIGTERM

--- a/jenkins/aws/deployRelease.sh
+++ b/jenkins/aws/deployRelease.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 trap 'exit 1' SIGHUP SIGINT SIGTERM

--- a/jenkins/aws/deploySetup.sh
+++ b/jenkins/aws/deploySetup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM

--- a/jenkins/aws/initDatabase.sh
+++ b/jenkins/aws/initDatabase.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/usr/bin/env bash -x
 
 # This script needs work - the content below was just captured here as a starting point
 # It is based on  a very old codeontap setup

--- a/jenkins/aws/integrator/addTenant.sh
+++ b/jenkins/aws/integrator/addTenant.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM

--- a/jenkins/aws/integrator/constructTree.sh
+++ b/jenkins/aws/integrator/constructTree.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM

--- a/jenkins/aws/integrator/setContext.sh
+++ b/jenkins/aws/integrator/setContext.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 [ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM

--- a/jenkins/aws/manageAccount.sh
+++ b/jenkins/aws/manageAccount.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 trap 'exit 1' SIGHUP SIGINT SIGTERM

--- a/jenkins/aws/manageBuildReferences.sh
+++ b/jenkins/aws/manageBuildReferences.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM

--- a/jenkins/aws/manageContentNode.sh
+++ b/jenkins/aws/manageContentNode.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM

--- a/jenkins/aws/manageDataSetRDSSnapshot.sh
+++ b/jenkins/aws/manageDataSetRDSSnapshot.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM

--- a/jenkins/aws/manageDataSetS3.sh
+++ b/jenkins/aws/manageDataSetS3.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM

--- a/jenkins/aws/manageDocker.sh
+++ b/jenkins/aws/manageDocker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM

--- a/jenkins/aws/manageEnvironment.sh
+++ b/jenkins/aws/manageEnvironment.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 trap 'exit 1' SIGHUP SIGINT SIGTERM

--- a/jenkins/aws/manageImages.sh
+++ b/jenkins/aws/manageImages.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Create/manage images corresponding to the current build
  

--- a/jenkins/aws/manageLambda.sh
+++ b/jenkins/aws/manageLambda.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM

--- a/jenkins/aws/managePipeline.sh
+++ b/jenkins/aws/managePipeline.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM

--- a/jenkins/aws/manageRDSSnapshot.sh
+++ b/jenkins/aws/manageRDSSnapshot.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 trap '[[ -z ${AUTOMATION_DEBUG} ]] && rm -rf ./temp_*; exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM

--- a/jenkins/aws/manageRepo.sh
+++ b/jenkins/aws/manageRepo.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM

--- a/jenkins/aws/manageS3Registry.sh
+++ b/jenkins/aws/manageS3Registry.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 trap '[[ -z ${AUTOMATION_DEBUG} ]] && rm -rf ./temp_*; exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM

--- a/jenkins/aws/manageScripts.sh
+++ b/jenkins/aws/manageScripts.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM

--- a/jenkins/aws/manageSpa.sh
+++ b/jenkins/aws/manageSpa.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM

--- a/jenkins/aws/manageSwagger.sh
+++ b/jenkins/aws/manageSwagger.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM

--- a/jenkins/aws/manageUnits.sh
+++ b/jenkins/aws/manageUnits.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 trap 'exit 1' SIGHUP SIGINT SIGTERM

--- a/jenkins/aws/prepareRelease.sh
+++ b/jenkins/aws/prepareRelease.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 trap 'exit 1' SIGHUP SIGINT SIGTERM

--- a/jenkins/aws/prepareReleaseSetup.sh
+++ b/jenkins/aws/prepareReleaseSetup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM

--- a/jenkins/aws/promoteRelease.sh
+++ b/jenkins/aws/promoteRelease.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM

--- a/jenkins/aws/runLambda.sh
+++ b/jenkins/aws/runLambda.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM

--- a/jenkins/aws/runPipeline.sh
+++ b/jenkins/aws/runPipeline.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM

--- a/jenkins/aws/runTasks.sh
+++ b/jenkins/aws/runTasks.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM

--- a/jenkins/aws/setCredentials.sh
+++ b/jenkins/aws/setCredentials.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Set up the access
 #

--- a/jenkins/aws/updateBuildReference.sh
+++ b/jenkins/aws/updateBuildReference.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ${AUTOMATION_DIR}/updateBuildReferences.sh

--- a/jenkins/aws/updateBuildReferences.sh
+++ b/jenkins/aws/updateBuildReferences.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM

--- a/jenkins/aws/validateAcceptReleaseParameters.sh
+++ b/jenkins/aws/validateAcceptReleaseParameters.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM

--- a/jenkins/aws/validateDeployReleaseParameters.sh
+++ b/jenkins/aws/validateDeployReleaseParameters.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM

--- a/jenkins/aws/validateUpdateBuildReferenceParameters.sh
+++ b/jenkins/aws/validateUpdateBuildReferenceParameters.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM

--- a/jenkins/aws/validateUpdateBuildReferencesParameters.sh
+++ b/jenkins/aws/validateUpdateBuildReferencesParameters.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM

--- a/setContext.sh
+++ b/setContext.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # AUTOMATION_BASE_DIR assumed to be pointing to base of gen3-automation tree
 

--- a/utility.sh
+++ b/utility.sh
@@ -684,14 +684,13 @@ function decrypt_kms_string() {
   local region="$1"; shift
   local value="$1"; shift
 
-  pushTempDir "${FUNCNAME[0]}_XXXXXX"
-  local tmp_file="$(getTopTempDir)/value"
+  local tmp_file="$(getTempFile)"
   local return_status
 
   echo "${value}" | base64 --decode > "${tmp_file}"
   aws --region "${region}" kms decrypt --ciphertext-blob "fileb://${tmp_file}" --output text --query Plaintext | base64 --decode; return_status=$?
 
-  popTempDir
+  rm ${tmp_file}
   return ${return_status}
 }
 


### PR DESCRIPTION
To use CodeOnTap on OSX we need to install a newer version of bash which is not installed in the standard location. Using /usr/bin/env bash gets around this and allows us to use the default bash version the user has defined. 

Also includes a minor fix to the way we get a temp file for kms decryption