### PR TITLE
add test build task support

### DIFF
--- a/jenkins/aws/buildPython.sh
+++ b/jenkins/aws/buildPython.sh
@@ -146,7 +146,7 @@ function main() {
     fi
   fi
   
-  if inArray "REQUIRED_TASKS" "test"; then
+  if inArray "REQUIRED_TASKS" "testviafile"; then
     # Run tests with a script file
     TEST_SCRIPT_FILE="${TEST_SCRIPT_FILE:-run_tests_ci.sh}"
     if [[ -f "${AUTOMATION_BUILD_SRC_DIR}/${TEST_SCRIPT_FILE}" ]]; then

--- a/jenkins/aws/buildPython.sh
+++ b/jenkins/aws/buildPython.sh
@@ -145,6 +145,16 @@ function main() {
       cd ${AUTOMATION_BUILD_SRC_DIR}
     fi
   fi
+  
+  if inArray "REQUIRED_TASKS" "test"; then
+    # Run tests with a script file
+    TEST_SCRIPT_FILE="${TEST_SCRIPT_FILE:-run_tests_ci.sh}"
+    if [[ -f "${AUTOMATION_BUILD_SRC_DIR}/${TEST_SCRIPT_FILE}" ]]; then
+      info "Running tests with ${TEST_SCRIPT_FILE} ..."
+      ./${TEST_SCRIPT_FILE} ||
+      { exit_status=$?; fatal "Tests failed"; return ${exit_status}; }
+    fi
+  fi
 
   if inArray "REQUIRED_TASKS" "swagger"; then
     # Generate swagger documents


### PR DESCRIPTION
The test build task will allow running unit and integration tests together to get a complete coverage report when it is needed. Also, it will allow setting up and tearing down the environment - starting postgres as a docker compose service and etc. A filename should be specified with `TEST_SCRIPT_FILE` environment variable, which has a default value `run_tests_ci.sh`.