### PR TITLE
<refactor> GEN3 directory tree to separate state

### DIFF
--- a/contextTree.sh
+++ b/contextTree.sh
@@ -204,8 +204,8 @@ function assemble_settings() {
     [[ -z "${name}" ]] && name="${id}"
     [[ (-n "${ACCOUNT}") && ("${ACCOUNT,,}" != "${name,,}") ]] && continue
 
-    local account_dir="$(filePath "${account_file}")/settings"
-    debug "Processing ${account_dir} ..."
+    local account_dir="$(findGen3AccountSettingsDir "${root_dir}" "${name}")"
+    debug "Processing account dir ${account_dir} ..."
     pushd "${account_dir}" > /dev/null 2>&1 || continue
 
     tmp_file="$( getTempFile "account_settings_XXXXXX.json" "${tmp_dir}")"
@@ -222,7 +222,6 @@ function assemble_settings() {
 
 #  debug "Products=${product_files[@]}"
 
-  # Settings
   for product_file in "${product_files[@]}"; do
 
     id="$(getJSONValue "${product_file}" ".Product.Id")"
@@ -230,103 +229,106 @@ function assemble_settings() {
     [[ -z "${name}" ]] && name="${id}"
     [[ (-n "${PRODUCT}") && ("${PRODUCT,,}" != "${name,,}") ]] && continue
 
-    local product_dir="$(filePath "${product_file}")/settings"
-    debug "Processing ${product_dir} ..."
-    pushd "${product_dir}" > /dev/null 2>&1 || continue
-
     # Settings
-    readarray -t setting_files < <(find . -type f \( \
-      -not \( -name "*build.json" -or -name "*credentials.json" -or -name "*sensitive.json" \) \
-      -and -not \( -path "*/asfile/*" -or -path "*/asFile/*" \) \
-      -and -not \( -name ".*" -or -path "*/.*/*" \) \) )
-    if ! arrayIsEmpty "setting_files" ; then
-      tmp_file="$( getTempFile "product_settings_XXXXXX.json" "${tmp_dir}")"
-      convertFilesToJSONObject "Settings Products" "${name}" "${root_dir}" "false" "${setting_files[@]}" > "${tmp_file}" || return 1
-      tmp_file_list+=("${tmp_file}")
-    fi
+    local settings_dir="$(findGen3ProductSettingsDir "${root_dir}" "${name}")"
+    if [[ -d "${settings_dir}" ]]; then
+      debug "Processing settings dir ${settings_dir} ..."
+      pushd "${settings_dir}" > /dev/null 2>&1 || continue
 
-    # Sensitive
-    readarray -t setting_files < <(find . -type f \( \
-      -name "*credentials.json" -or -name "*sensitive.json" \
-      -and -not \( -path "*/asfile/*" -or -path "*/asFile/*" \) \
-      -and -not \( -name ".*" -or -path "*/.*/*" \) \) )
-    if ! arrayIsEmpty "setting_files" ; then
-      tmp_file="$( getTempFile "product_sensitive_XXXXXX.json" "${tmp_dir}")"
-      convertFilesToJSONObject "Sensitive Products" "${name}" "${root_dir}" "false" "${setting_files[@]}" > "${tmp_file}" || return 1
-      tmp_file_list+=("${tmp_file}")
+      # Settings
+      readarray -t setting_files < <(find . -type f \( \
+        -not \( -name "*build.json" -or -name "*credentials.json" -or -name "*sensitive.json" \) \
+        -and -not \( -path "*/asfile/*" -or -path "*/asFile/*" \) \
+        -and -not \( -name ".*" -or -path "*/.*/*" \) \) )
+      if ! arrayIsEmpty "setting_files" ; then
+        tmp_file="$( getTempFile "product_settings_XXXXXX.json" "${tmp_dir}")"
+        convertFilesToJSONObject "Settings Products" "${name}" "${root_dir}" "false" "${setting_files[@]}" > "${tmp_file}" || return 1
+        tmp_file_list+=("${tmp_file}")
+      fi
+
+      # Sensitive
+      readarray -t setting_files < <(find . -type f \( \
+        \( -name "*credentials.json" -or -name "*sensitive.json" \) \
+        -and -not \( -path "*/asfile/*" -or -path "*/asFile/*" \) \
+        -and -not \( -name ".*" -or -path "*/.*/*" \) \) )
+      if ! arrayIsEmpty "setting_files" ; then
+        tmp_file="$( getTempFile "product_sensitive_XXXXXX.json" "${tmp_dir}")"
+        convertFilesToJSONObject "Sensitive Products" "${name}" "${root_dir}" "false" "${setting_files[@]}" > "${tmp_file}" || return 1
+        tmp_file_list+=("${tmp_file}")
+      fi
+
+      # asFiles
+      readarray -t setting_files < <(find . -type f \( \
+        \( -path "*/asfile/*" -or -path "*/asFile/*" \) \
+        -and -not \( -name ".*" -or -path "*/.*/*" \) \) )
+      if ! arrayIsEmpty "setting_files" ; then
+        tmp_file="$( getTempFile "product_settings_asfile_XXXXXX.json" "${tmp_dir}")"
+        convertFilesToJSONObject "Settings Products" "${name}" "${root_dir}" "true" "${setting_files[@]}" > "${tmp_file}" || return 1
+        tmp_file_list+=("${tmp_file}")
+      fi
+
+      popd > /dev/null
     fi
 
     # Builds
-    readarray -t setting_files < <(find . -type f \( \
-      -name "*build.json" \
-      -and -not \( -path "*/asfile/*" -or -path "*/asFile/*" \) \
-      -and -not \( -name ".*" -or -path "*/.*/*" \) \) )
-    if ! arrayIsEmpty "setting_files" ; then
-      tmp_file="$( getTempFile "product_builds_XXXXXX.json" "${tmp_dir}")"
-      convertFilesToJSONObject "Builds Products" "${name}" "${root_dir}" "false" "${setting_files[@]}" > "${tmp_file}" || return 1
-      tmp_file_list+=("${tmp_file}")
+    local builds_dir="$(findGen3ProductBuildsDir "${root_dir}" "${name}")"
+    if [[ -d "${builds_dir}" ]]; then
+      debug "Processing builds dir ${builds_dir} ..."
+      pushd "${builds_dir}" > /dev/null
+
+      readarray -t build_files < <(find . -type f \( \
+        -name "*build.json" \
+        -and -not \( -path "*/asfile/*" -or -path "*/asFile/*" \) \
+        -and -not \( -name ".*" -or -path "*/.*/*" \) \) )
+      if ! arrayIsEmpty "build_files" ; then
+        tmp_file="$( getTempFile "builds_builds_XXXXXX.json" "${tmp_dir}")"
+        convertFilesToJSONObject "Builds Products" "${name}" "${root_dir}" "false" "${build_files[@]}" > "${tmp_file}" || return 1
+        tmp_file_list+=("${tmp_file}")
+      fi
+
+      popd > /dev/null
     fi
 
-    # asFiles
-    readarray -t setting_files < <(find . -type f \( \
-      \( -path "*/asfile/*" -or -path "*/asFile/*" \) \
-      -and -not \( -name ".*" -or -path "*/.*/*" \) \) )
-    if ! arrayIsEmpty "setting_files" ; then
-      tmp_file="$( getTempFile "product_settings_asfile_XXXXXX.json" "${tmp_dir}")"
-      convertFilesToJSONObject "Settings Products" "${name}" "${root_dir}" "true" "${setting_files[@]}" > "${tmp_file}" || return 1
-      tmp_file_list+=("${tmp_file}")
+    # Operations
+    local operations_dir="$(findGen3ProductOperationsDir "${root_dir}" "${name}")"
+    if [[ -d "${operations_dir}" ]]; then
+      debug "Processing operations dir ${operations_dir} ..."
+      pushd "${operations_dir}" > /dev/null
+
+      # Settings
+      readarray -t setting_files < <(find . -type f \( \
+        -not \( -name "*build.json" -or -name "*credentials.json" -or -name "*sensitive.json" \) \
+        -and -not \( -path "*/asfile/*" -or -path "*/asFile/*" \) \
+        -and -not \( -name ".*" -or -path "*/.*/*" \) \) )
+      if ! arrayIsEmpty "setting_files" ; then
+        tmp_file="$( getTempFile "operations_settings_XXXXXX.json" "${tmp_dir}")"
+        convertFilesToJSONObject "Settings Products" "${name}" "${root_dir}" "false" "${setting_files[@]}" > "${tmp_file}" || return 1
+        tmp_file_list+=("${tmp_file}")
+      fi
+
+      # Sensitive
+      readarray -t setting_files < <(find . -type f \( \
+        \( -name "*credentials.json" -or -name "*sensitive.json" \) \
+        -and -not \( -path "*/asfile/*" -or -path "*/asFile/*" \) \
+        -and -not \( -name ".*" -or -path "*/.*/*" \) \) )
+      if ! arrayIsEmpty "setting_files" ; then
+        tmp_file="$( getTempFile "operations_sensitive_XXXXXX.json" "${tmp_dir}")"
+        convertFilesToJSONObject "Sensitive Products" "${name}" "${root_dir}" "false" "${setting_files[@]}" > "${tmp_file}" || return 1
+        tmp_file_list+=("${tmp_file}")
+      fi
+
+      # asFiles
+      readarray -t setting_files < <(find . -type f \( \
+        \( -path "*/asfile/*" -or -path "*/asFile/*" \) \
+        -and -not \( -name ".*" -or -path "*/.*/*" \) \) )
+      if ! arrayIsEmpty "setting_files" ; then
+        tmp_file="$( getTempFile "operations_settings_asfile_XXXXXX.json" "${tmp_dir}")"
+        convertFilesToJSONObject "Settings Products" "${name}" "${root_dir}" "true" "${setting_files[@]}" > "${tmp_file}" || return 1
+        tmp_file_list+=("${tmp_file}")
+      fi
+
+      popd > /dev/null
     fi
-
-    popd > /dev/null
-
-  done
-
-  # Operations
-  for product_file in "${product_files[@]}"; do
-
-    id="$(getJSONValue "${product_file}" ".Product.Id")"
-    name="$(getJSONValue "${product_file}" ".Product.Name")"
-    [[ -z "${name}" ]] && name="${id}"
-    [[ (-n "${PRODUCT}") && ("${PRODUCT,,}" != "${name,,}") ]] && continue
-
-    local operations_dir="$(findGen3ProductInfrastructureDir "${root_dir}" "${name}")/operations"
-    debug "Processing ${operations_dir} ..."
-    pushd "${operations_dir}" > /dev/null 2>&1 || continue
-
-    # Settings
-    readarray -t setting_files < <(find . -type f \( \
-      -not \( -name "*build.json" -or -name "*credentials.json" -or -name "*sensitive.json" \) \
-      -and -not \( -path "*/asfile/*" -or -path "*/asFile/*" \) \
-      -and -not \( -name ".*" -or -path "*/.*/*" \) \) )
-    if ! arrayIsEmpty "setting_files" ; then
-      tmp_file="$( getTempFile "operations_settings_XXXXXX.json" "${tmp_dir}")"
-      convertFilesToJSONObject "Settings Products" "${name}" "${root_dir}" "false" "${setting_files[@]}" > "${tmp_file}" || return 1
-      tmp_file_list+=("${tmp_file}")
-    fi
-
-    # Sensitive
-    readarray -t setting_files < <(find . -type f \( \
-      -name "*credentials.json" -or -name "*sensitive.json" \
-      -and -not \( -path "*/asfile/*" -or -path "*/asFile/*" \) \
-      -and -not \( -name ".*" -or -path "*/.*/*" \) \) )
-    if ! arrayIsEmpty "setting_files" ; then
-      tmp_file="$( getTempFile "operations_sensitive_XXXXXX.json" "${tmp_dir}")"
-      convertFilesToJSONObject "Sensitive Products" "${name}" "${root_dir}" "false" "${setting_files[@]}" > "${tmp_file}" || return 1
-      tmp_file_list+=("${tmp_file}")
-    fi
-
-    # asFiles
-    readarray -t setting_files < <(find . -type f \( \
-      \( -path "*/asfile/*" -or -path "*/asFile/*" \) \
-      -and -not \( -name ".*" -or -path "*/.*/*" \) \) )
-    if ! arrayIsEmpty "setting_files" ; then
-      tmp_file="$( getTempFile "operations_settings_asfile_XXXXXX.json" "${tmp_dir}")"
-      convertFilesToJSONObject "Settings Products" "${name}" "${root_dir}" "true" "${setting_files[@]}" > "${tmp_file}" || return 1
-      tmp_file_list+=("${tmp_file}")
-    fi
-
-    popd > /dev/null
-
   done
 
   # Generate the merged output
@@ -347,11 +349,11 @@ function assemble_composite_definitions() {
 
   local definitions_array=()
   [[ (-n "${ACCOUNT}") ]] &&
-      addToArray "definitions_array" "${ACCOUNT_INFRASTRUCTURE_DIR}"/cf/shared/defn*-definition.json
+      addToArray "definitions_array" "${ACCOUNT_STATE_DIR}"/cf/shared/defn*-definition.json
   [[ (-n "${PRODUCT}") && (-n "${REGION}") ]] &&
-      addToArray "definitions_array" "${PRODUCT_INFRASTRUCTURE_DIR}"/cf/shared/defn*-"${REGION}"*-definition.json
+      addToArray "definitions_array" "${PRODUCT_STATE_DIR}"/cf/shared/defn*-"${REGION}"*-definition.json
   [[ (-n "${ENVIRONMENT}") && (-n "${SEGMENT}") && (-n "${REGION}") ]] &&
-      addToArray "definitions_array" "${PRODUCT_INFRASTRUCTURE_DIR}/cf/${ENVIRONMENT}/${SEGMENT}"/*-definition.json
+      addToArray "definitions_array" "${PRODUCT_STATE_DIR}/cf/${ENVIRONMENT}/${SEGMENT}"/*-definition.json
 
   ${restore_nullglob}
 
@@ -374,11 +376,11 @@ function assemble_composite_stack_outputs() {
 
   local stack_array=()
   [[ (-n "${ACCOUNT}") ]] &&
-      addToArray "stack_array" "${ACCOUNT_INFRASTRUCTURE_DIR}"/cf/shared/acc*-stack.json
+      addToArray "stack_array" "${ACCOUNT_STATE_DIR}"/cf/shared/acc*-stack.json
   [[ (-n "${PRODUCT}") && (-n "${REGION}") ]] &&
-      addToArray "stack_array" "${PRODUCT_INFRASTRUCTURE_DIR}"/cf/shared/product*-"${REGION}"*-stack.json
+      addToArray "stack_array" "${PRODUCT_STATE_DIR}"/cf/shared/product*-"${REGION}"*-stack.json
   [[ (-n "${ENVIRONMENT}") && (-n "${SEGMENT}") && (-n "${REGION}") ]] &&
-      addToArray "stack_array" "${PRODUCT_INFRASTRUCTURE_DIR}/cf/${ENVIRONMENT}/${SEGMENT}"/*-stack.json
+      addToArray "stack_array" "${PRODUCT_STATE_DIR}/cf/${ENVIRONMENT}/${SEGMENT}"/*-stack.json
 
   ${restore_nullglob}
 
@@ -405,6 +407,13 @@ function assemble_composite_stack_outputs() {
     done
     debug "MODIFIED_STACK_OUTPUTS=${modified_stack_array[*]}"
     ${GENERATION_DIR}/manageJSON.sh -f "[.[].Stacks | select(.!=null) | .[].Outputs | select(.!=null) ]" -o "${COMPOSITE_STACK_OUTPUTS}" "${modified_stack_array[@]}"
+
+    # TODO(rossmurr4y): Make this logic provider independant - based on details specified elsewhere in the plugin.
+    # if composite outputs is found empty, re-filter with Azure formatted outputs
+    if [[ $( jq -r '.|tostring == "[]"' < "${COMPOSITE_STACK_OUTPUTS}" ) == "true" ]]; then
+      ${GENERATION_DIR}/manageJSON.sh -f ".[].properties.outputs | select(.!=null)" -o "${COMPOSITE_STACK_OUTPUTS}" "${modified_stack_array[@]}"
+    fi
+
   else
     echo "[]" > "${COMPOSITE_STACK_OUTPUTS}"
   fi
@@ -432,13 +441,13 @@ function getCmk() {
 
 function encrypt_file() {
   local region="$1"; shift
-  local level="$1"; shift
+  local key_id="$1"; shift
   local input_file="$1"; shift
   local output_file="$1"; shift
 
   pushTempDir "${FUNCNAME[0]}_XXXXXX"
   local tmp_dir="$(getTopTempDir)"
-  local cmk=$(getCmk "${level}")
+  local cmk=$(getCompositeStackOutput "${COMPOSITE_STACK_OUTPUTS}" "${key_id}")
   local return_status
 
   cp "${input_file}" "${tmp_dir}/encrypt_file"
@@ -519,11 +528,52 @@ function findGen3AccountDir() {
     "${account}/config/account.json"
 }
 
+function findGen3AccountSettingsDir() {
+  local root_dir="$1"; shift
+  local account="$1"; shift
+
+  local account_dir="$(findGen3AccountDir "${root_dir}" "${account}")"
+  if [[ -n "${account_dir}" ]]; then
+    echo -n "${account_dir}/settings"
+    return 0
+  fi
+  return 1
+}
+
 function findGen3AccountInfrastructureDir() {
   local root_dir="$1"; shift
   local account="$1"; shift
 
   findDir "${root_dir}" \
+    "infrastructure/**/${account}" \
+    "${account}/infrastructure"
+}
+
+# It would be very rare that accounts would have standard settings and operations
+# settings as normally the accounts tree is controlled by the operations team.
+# Thus the settings directory should be adequate. Nonetheless it allows consistency
+# if the operations team always put their settings in the operations directory,
+# regardless of repo.
+function findGen3AccountOperationsDir() {
+  local root_dir="$1"; shift
+  local account="$1"; shift
+
+  # TODO(mfl): Remove infrastructure checks when all repos converted to >=v2.0.0
+  findDir "${root_dir}" \
+    "operations/**/${account}/settings" \
+    "${account}/operations/settings" \
+    "infrastructure/**/${account}/operations" \
+    "${account}/infrastructure/operations"
+}
+
+function findGen3AccountStateDir() {
+  local root_dir="$1"; shift
+  local account="$1"; shift
+
+  # TODO(mfl): Remove infrastructure checks when all repos converted to >=v2.0.0
+  findDir "${root_dir}" \
+    "state/**/${account}" \
+    "${account}/state" \
     "infrastructure/**/${account}" \
     "${account}/infrastructure"
 }
@@ -537,6 +587,18 @@ function findGen3ProductDir() {
     "${product}/config/product.json"
 }
 
+function findGen3ProductSettingsDir() {
+  local root_dir="$1"; shift
+  local product="$1"; shift
+
+  local product_dir="$(findGen3ProductDir "${root_dir}" "${product}")"
+  if [[ -n "${product_dir}" ]]; then
+    echo -n "${product_dir}/settings"
+    return 0
+  fi
+  return 1
+}
+
 function findGen3ProductInfrastructureDir() {
   local root_dir="$1"; shift
   local product="$1"; shift
@@ -546,15 +608,75 @@ function findGen3ProductInfrastructureDir() {
     "${product}/infrastructure"
 }
 
-function findGen3EnvironmentDir() {
+function findGen3ProductOperationsDir() {
   local root_dir="$1"; shift
-  local product="${1:-${PRODUCT}}"; shift
-  local environment="${1:-${ENVIRONMENT}}"; shift
+  local product="$1"; shift
 
-  local product_dir="$(findGen3ProductDir "${root_dir}" "${product}")"
-  [[ -z "${product_dir}" ]] && return 1
+  # TODO(mfl): Remove infrastructure checks when all repos converted to >=v2.0.0
+  findDir "${root_dir}" \
+    "operations/**/${product}/settings" \
+    "${product}/operations/settings" \
+    "infrastructure/**/${product}/operations" \
+    "${product}/infrastructure/operations"
+}
 
-  findDir "${product_dir}" "solutionsv2/${environment}/environment.json"
+function findGen3ProductSolutionsDir() {
+  local root_dir="$1"; shift
+  local product="$1"; shift
+
+  # TODO(mfl): Remove config checks when all repos converted to >=v2.0.0
+  findDir "${root_dir}" \
+    "infrastructure/**/${product}/solutions" \
+    "${product}/infrastructure/solutions" \
+    "config/**/${product}/solutionsv2" \
+    "${product}/config/solutionsv2"
+}
+
+function findGen3ProductBuildsDir() {
+  local root_dir="$1"; shift
+  local product="$1"; shift
+
+  # TODO(mfl): Remove config checks when all repos converted to >=v2.0.0
+  findDir "${root_dir}" \
+    "infrastructure/**/${product}/builds" \
+    "${product}/infrastructure/builds" \
+    "config/**/${product}/settings" \
+    "${product}/config/settings"
+}
+
+function findGen3ProductStateDir() {
+  local root_dir="$1"; shift
+  local product="$1"; shift
+
+  # TODO(mfl): Remove infrastructure checks when all repos converted to >=v2.0.0
+  findDir "${root_dir}" \
+    "state/**/${product}" \
+    "${product}/state" \
+    "infrastructure/**/${product}" \
+    "${product}/infrastructure"
+}
+
+function findGen3ProductEnvironmentDir() {
+  local root_dir="$1"; shift
+  local product="$1"; shift
+  local environment="$1"; shift
+
+  local solutions_dir="$(findGen3ProductSolutionsDir "${root_dir}" "${product}")"
+  [[ -z "${solutions_dir}" ]] && return 1
+
+  findDir "${solutions_dir}" "${environment}/environment.json"
+}
+
+function findGen3ProductEnvironmentSegmentDir() {
+  local root_dir="$1"; shift
+  local product="$1"; shift
+  local environment="$1"; shift
+  local segment="$1"; shift
+
+  local environment_dir="$(findGen3ProductEnvironmentDir "${root_dir}" "${product}" "${environment}")"
+  [[ -z "${environment_dir}" ]] && return 1
+
+  findDir "${environment_dir}" "${segment}/segment.json"
 }
 
 function getGen3Env() {
@@ -603,48 +725,71 @@ function findGen3Dirs() {
     "$(findGen3AccountDir "${root_dir}" "${account}" )" || return 1
   debug "ACCOUNT_DIR=${ACCOUNT_DIR}"
 
+  setGen3DirEnv "ACCOUNT_SETTINGS_DIR" "${prefix}" \
+    "$(findGen3AccountSettingsDir "${root_dir}" "${account}" )" || return 1
+  debug "ACCOUNT_SETTINGS_DIR=${ACCOUNT_SETTINGS_DIR}"
+
   setGen3DirEnv "ACCOUNT_INFRASTRUCTURE_DIR" "${prefix}" \
     "$(findGen3AccountInfrastructureDir "${root_dir}" "${account}" )" || return 1
   debug "ACCOUNT_INFRASTRUCTURE_DIR=${ACCOUNT_INFRASTRUCTURE_DIR}"
 
-  declare -gx ${prefix}ACCOUNT_SETTINGS_DIR=$(getGen3Env "ACCOUNT_DIR" "${prefix}")/settings
-  declare -gx ${prefix}ACCOUNT_OPERATIONS_DIR=$(getGen3Env "ACCOUNT_INFRASTRUCTURE_DIR" "${prefix}")/operations
+  setGen3DirEnv "ACCOUNT_OPERATIONS_DIR" "${prefix}" \
+    "$(findGen3AccountOperationsDir "${root_dir}" "${account}" )" || return 1
+  debug "ACCOUNT_OPERATIONS_DIR=${ACCOUNT_OPERATIONS_DIR}"
+
+  setGen3DirEnv "ACCOUNT_STATE_DIR" "${prefix}" \
+    "$(findGen3AccountStateDir "${root_dir}" "${account}" )" || return 1
+  debug "ACCOUNT_STATE_DIR=${ACCOUNT_STATE_DIR}"
 
   if [[ -n "${product}" ]]; then
     setGen3DirEnv "PRODUCT_DIR" "${prefix}" \
       "$(findGen3ProductDir "${root_dir}" "${product}")" || return 1
     debug "PRODUCT_DIR=${PRODUCT_DIR}"
 
+    setGen3DirEnv "PRODUCT_SETTINGS_DIR" "${prefix}" \
+      "$(findGen3ProductSettingsDir "${root_dir}" "${product}" )" || return 1
+    debug "PRODUCT_SETTINGS_DIR=${PRODUCT_SETTINGS_DIR}"
+
     setGen3DirEnv "PRODUCT_INFRASTRUCTURE_DIR" "${prefix}" \
       "$(findGen3ProductInfrastructureDir "${root_dir}" "${product}")" || return 1
     debug "PRODUCT_INFRASTRUCTURE_DIR=${PRODUCT_INFRASTRUCTURE_DIR}"
 
-    declare -gx ${prefix}PRODUCT_SETTINGS_DIR=$(getGen3Env   "PRODUCT_DIR"                "${prefix}")/settings
-    declare -gx ${prefix}PRODUCT_SOLUTIONS_DIR=$(getGen3Env  "PRODUCT_DIR"                "${prefix}")/solutionsv2
-    declare -gx ${prefix}PRODUCT_OPERATIONS_DIR=$(getGen3Env "PRODUCT_INFRASTRUCTURE_DIR" "${prefix}")/operations
+    setGen3DirEnv "PRODUCT_OPERATIONS_DIR" "${prefix}" \
+      "$(findGen3ProductOperationsDir "${root_dir}" "${product}" )" || return 1
+    debug "PRODUCT_OPERATIONS_DIR=${PRODUCT_OPERATIONS_DIR}"
+
+    setGen3DirEnv "PRODUCT_SOLUTIONS_DIR" "${prefix}" \
+      "$(findGen3ProductSolutionsDir "${root_dir}" "${product}")" || return 1
+    debug "PRODUCT_SOLUTIONS_DIR=${PRODUCT_SOLUTIONS_DIR}"
+
+    setGen3DirEnv "PRODUCT_BUILDS_DIR" "${prefix}" \
+      "$(findGen3ProductBuildsDir "${root_dir}" "${product}")" || return 1
+    debug "PRODUCT_BUILDS_DIR=${PRODUCT_BUILDS_DIR}"
+
+    setGen3DirEnv "PRODUCT_STATE_DIR" "${prefix}" \
+      "$(findGen3ProductStateDir "${root_dir}" "${product}" )" || return 1
+    debug "PRODUCT_STATE_DIR=${PRODUCT_STATE_DIR}"
 
     declare -gx ${prefix}PRODUCT_SHARED_SETTINGS_DIR=$(getGen3Env   "PRODUCT_SETTINGS_DIR"   "${prefix}")/shared
     declare -gx ${prefix}PRODUCT_SHARED_SOLUTIONS_DIR=$(getGen3Env  "PRODUCT_SOLUTIONS_DIR"  "${prefix}")/shared
     declare -gx ${prefix}PRODUCT_SHARED_OPERATIONS_DIR=$(getGen3Env "PRODUCT_OPERATIONS_DIR" "${prefix}")/shared
 
     if [[ -n "${environment}" ]]; then
-
+      debug "ENVIRONMENT_DIR=$(findGen3ProductEnvironmentDir "${root_dir}" "${product}" "${environment}")"
       declare -gx ${prefix}ENVIRONMENT_SHARED_SETTINGS_DIR=$(getGen3Env   "PRODUCT_SETTINGS_DIR"   "${prefix}")/${environment}
       declare -gx ${prefix}ENVIRONMENT_SHARED_SOLUTIONS_DIR=$(getGen3Env  "PRODUCT_SOLUTIONS_DIR"  "${prefix}")/${environment}
       declare -gx ${prefix}ENVIRONMENT_SHARED_OPERATIONS_DIR=$(getGen3Env "PRODUCT_OPERATIONS_DIR" "${prefix}")/${environment}
-      debug "ENVIRONMENT_DIR=$(getGen3Env "PRODUCT_SOLUTIONS_DIR" "${prefix}")/${environment}"
 
       if [[ -n "${segment}" ]]; then
-
+        debug "SEGMENT_DIR=$(findGen3ProductEnvironmentSegmentDir "${root_dir}" "${product}" "${environment}" "${segment}")"
         declare -gx ${prefix}SEGMENT_SHARED_SETTINGS_DIR=$(getGen3Env   "PRODUCT_SETTINGS_DIR"   "${prefix}")/shared/${segment}
         declare -gx ${prefix}SEGMENT_SHARED_SOLUTIONS_DIR=$(getGen3Env  "PRODUCT_SOLUTIONS_DIR"  "${prefix}")/shared/${segment}
         declare -gx ${prefix}SEGMENT_SHARED_OPERATIONS_DIR=$(getGen3Env "PRODUCT_OPERATIONS_DIR" "${prefix}")/shared/${segment}
 
         declare -gx ${prefix}SEGMENT_SETTINGS_DIR=$(getGen3Env   "PRODUCT_SETTINGS_DIR"   "${prefix}")/${environment}/${segment}
-        declare -gx ${prefix}SEGMENT_BUILDS_DIR=$(getGen3Env     "PRODUCT_SETTINGS_DIR"   "${prefix}")/${environment}/${segment}
+        declare -gx ${prefix}SEGMENT_BUILDS_DIR=$(getGen3Env     "PRODUCT_BUILDS_DIR"   "${prefix}")/${environment}/${segment}
         declare -gx ${prefix}SEGMENT_SOLUTIONS_DIR=$(getGen3Env  "PRODUCT_SOLUTIONS_DIR"  "${prefix}")/${environment}/${segment}
         declare -gx ${prefix}SEGMENT_OPERATIONS_DIR=$(getGen3Env "PRODUCT_OPERATIONS_DIR" "${prefix}")/${environment}/${segment}
-        debug "SEGMENT_DIR=$(getGen3Env "PRODUCT_SOLUTIONS_DIR" "${prefix}")/${environment}/${segment}"
       fi
     fi
   fi
@@ -711,7 +856,7 @@ function isValidUnit() {
   # Check unit if required
   if [[ "${unit_required[${level}]}" == "true" ]]; then
     # Default deployment units for each level
-    declare -ga ACCOUNT_UNITS_ARRAY=("audit" "s3" "cert" "roles" "apigateway" "waf")
+    declare -ga ACCOUNT_UNITS_ARRAY=("iam" "lg" "audit" "s3" "cert" "roles" "apigateway" "waf" "sms" "console")
     declare -ga PRODUCT_UNITS_ARRAY=("s3" "sns" "cert" "cmk")
     declare -ga BUILDBLUEPRINT_UNITS_ARRAY=(${unit})
     declare -ga APPLICATION_UNITS_ARRAY=(${unit})
@@ -1101,9 +1246,11 @@ function cleanup_cmdb_repo_to_v1_1_0() {
   local dry_run="$1";shift
 
   for source in "${!upgrade_v1_1_0_sources[@]}"; do
-    readarray -t source_dirs < <(find "${root_dir}" -mindepth 1 -maxdepth 1 -type d \
-      -name "${source}" )
+    readarray -t source_dirs < <(find "${root_dir}" -type d -name "${source}" )
     for source_dir in "${source_dirs[@]}"; do
+      local target_dir="$(filePath "${source_dir}")/${upgrade_v1_1_0_sources[${source}]}"
+      debug "Checking ${source_dir} ..."
+      [[ ! -d "${target_dir}" ]] && continue
       info "Deleting ${source_dir} ..."
       [[ -n "${dry_run}" ]] && continue
       git_rm -rf "${source_dir}" || return 1
@@ -1113,9 +1260,411 @@ function cleanup_cmdb_repo_to_v1_1_0() {
   return 0
 }
 
+function cleanup_cmdb_repo_to_v1_1_1() {
+  # Rerun 1.1.0 to pick up errors in original implementation
+  # Previously it only worked for product repos but now should
+  # work for all repos
+  cleanup_cmdb_repo_to_v1_1_0 "$@"
+}
+
+function cleanup_cmdb_repo_to_v2_0_0() {
+  local root_dir="$1";shift
+  local dry_run="$1";shift
+
+  readarray -t config_dirs < <(find "${root_dir}" -type d -name "config" )
+  for config_dir in "${config_dirs[@]}"; do
+    local solutions_dir="${config_dir}/solutionsv2"
+    if [[ -d "${solutions_dir}" ]]; then
+      info "Deleting ${solutions_dir} ..."
+      [[ -n "${dry_run}" ]] && continue
+      git_rm -rf "${solutions_dir}" || return 1
+    fi
+  done
+
+  return 0
+}
+
+# container_* files now should be fragment_*
+function upgrade_cmdb_repo_to_v1_2_0() {
+  local root_dir="$1";shift
+  local dry_run="$1";shift
+
+  pushTempDir "${FUNCNAME[0]}_$(fileName "${root_dir}")_XXXXXX"
+  local tmp_dir="$(getTopTempDir)"
+  local return_status=0
+
+  readarray -t legacy_files < <(find "${root_dir}" -type f \
+    -name "container_*.ftl" )
+  for legacy_file in "${legacy_files[@]}"; do
+    debug "Checking ${legacy_file}..."
+    replacement_filename="$(fileName "${legacy_file}")"
+    replacement_filename="${replacement_filename/container_/fragment_}"
+    replacement_file="$(filePath "${legacy_file}")/${replacement_filename}"
+    [[ -f "${replacement_file}" ]] && continue
+    info "Renaming ${legacy_file} to ${replacement_file}..."
+
+    if [[ -n "${dry_run}" ]]; then
+      continue
+    fi
+    git_mv "${legacy_file}" "${replacement_file}" || { return_status=1; break; }
+  done
+
+  popTempDir
+
+  return ${return_status}
+}
+
+function upgrade_cmdb_repo_to_v1_3_0() {
+  local root_dir="$1";shift
+  local dry_run="$1";shift
+
+  pushTempDir "${FUNCNAME[0]}_$(fileName "${root_dir}")_XXXXXX"
+  local tmp_dir="$(getTopTempDir)"
+  local return_status=0
+
+  # Find accounts
+  local -A account_mappings
+  readarray -t account_files < <(find "${GENERATION_DATA_DIR}" -type f -name "account.json" )
+  for account_file in "${account_files[@]}"; do
+    aws_id="$( jq -r '.Account.AWSId' <"${account_file}" )"
+    account_id="$( jq -r '.Account.Id' < "${account_file}" )"
+    account_mappings+=(["${aws_id}"]="${account_id}")
+  done
+
+  readarray -t cf_dirs < <(find "${root_dir}" -type d -name "cf" )
+  for cf_dir in "${cf_dirs[@]}"; do
+    readarray -t cmk_stacks < <(find "${cf_dir}" -type f -name "seg-cmk-*[0-9]-stack.json" )
+    for cmk_stack in "${cmk_stacks[@]}"; do
+
+      info "Looking for CMK account in ${cmk_stack} ..."
+      cmk_account="$( jq -r '.Stacks[0].Outputs[] | select( .OutputKey=="Account" ) | .OutputValue' < "${cmk_stack}" )"
+      cmk_region="$( jq -r '.Stacks[0].Outputs[] | select( .OutputKey=="Region" ) | .OutputValue' < "${cmk_stack}" )"
+
+      if [[ -n "${cmk_account}" ]]; then
+        cmk_account_id="${account_mappings[${cmk_account}]}"
+        cmk_path="$(filePath "${cmk_stack}")"
+
+        readarray -t segment_stacks < <(find "${cmk_path}"  -type f -name "*stack.json")
+        for stack_file in "${segment_stacks[@]}"; do
+
+          parse_stack_filename "${stack_file}"
+          stack_dir="$(filePath "${stack_file}")"
+          stack_filename="$(fileName "${stack_file}")"
+
+          # Add Standard Account and Region Stack Outputs
+          stackoutput_account="$( jq -r '.Stacks[0].Outputs[] | select( .OutputKey=="Account" ) | .OutputValue' < "${stack_file}" )"
+          stackoutput_region="$( jq -r '.Stacks[0].Outputs[] | select( .OutputKey=="Region" ) | .OutputValue' < "${stack_file}" )"
+          stackoutput_level="$( jq -r '.Stacks[0].Outputs[] | select( .OutputKey=="Level" ) | .OutputValue' < "${stack_file}" )"
+          stackoutput_deployment_unit="$( jq -r '.Stacks[0].Outputs[] | select( .OutputKey=="DeploymentUnit" ) | .OutputValue' < "${stack_file}" )"
+
+          if [[ -z "${stackoutput_account}" ]]; then
+              debug "Adding Account Output to ${stack_file} ..."
+              jq -r --arg account "${cmk_account}" '.Stacks[].Outputs += [{ "OutputKey" : "Account", "OutputValue" : $account  }]' < "${stack_file}" > "${tmp_dir}/${stack_filename}"
+              if [[ $? == 0 ]]; then
+                mv "${tmp_dir}/${stack_filename}" "${stack_file}"
+              fi
+          fi
+
+          if [[ -z "${stackoutput_region}" ]]; then
+              debug "Adding Region Output to ${stack_file} ..."
+              jq -r --arg region "${stack_region}" '.Stacks[].Outputs += [{ "OutputKey" : "Region", "OutputValue" : $region  }]' < "${stack_file}" > "${tmp_dir}/${stack_filename}"
+              if [[ $? == 0 ]]; then
+                mv "${tmp_dir}/${stack_filename}" "${stack_file}"
+              fi
+          fi
+
+
+          if [[ -z "${stack_account}" ]]; then
+
+            # Rename file to inclue Region and Account
+            stack_file_name="$(fileName "${stack_file}" )"
+            new_stack_file_name="${stack_file_name/"-${stack_region}-"/-${cmk_account_id}-${stack_region}-}"
+
+            if [[ "${stack_file_name}" != "${new_stack_file_name}" && "${stack_file_name}" != *"${cmk_account_id}"* ]]; then
+              debug "Moving ${stack_file} to ${stack_dir}/${new_stack_file_name} ..."
+
+              if [[ -n "${dry_run}" ]]; then
+                continue
+              fi
+
+              git_mv "${stack_file}" "${stack_dir}/${new_stack_file_name}"
+            fi
+          fi
+        done
+
+        # Rename SSH keys to include Account/Region
+        operations_path="${cmk_path/"infrastructure/cf"/infrastructure/operations}"
+
+        info "Checking for SSH Keys in ${operations_path} ..."
+        readarray -t pem_files < <(find "${operations_path}" -type f -name ".aws-ssh*.pem*" )
+
+        for pem_file in "${pem_files[@]}"; do
+          local pem_file_path="$(filePath "${pem_file}")"
+          local file_name="$(fileName "${pem_file}")"
+          local new_file_name="${file_name/aws-/aws-${cmk_account_id}-${cmk_region}-}"
+
+          # Move the pem files to make them invisible to the generation process
+          debug "Moving ${pem_file} to ${pem_file_path}/${new_file_name} ..."
+
+          if [[ -n "${dry_run}" ]]; then
+            continue
+          fi
+          git_mv "${pem_file}" "${pem_file_path}/${new_file_name}"
+        done
+      fi
+    done
+  done
+
+  popTempDir
+
+  return $return_status
+}
+
+function upgrade_cmdb_repo_to_v1_3_1() {
+  local root_dir="$1";shift
+  local dry_run="$1";shift
+
+  pushTempDir "${FUNCNAME[0]}_$(fileName "${root_dir}")_XXXXXX"
+  local tmp_dir="$(getTopTempDir)"
+  local return_status=0
+
+  # Find accounts
+  local -A account_mappings
+  readarray -t account_files < <(find "${GENERATION_DATA_DIR}" -type f -name "account.json" )
+  for account_file in "${account_files[@]}"; do
+    aws_id="$( jq -r '.Account.AWSId' <"${account_file}" )"
+    account_id="$( jq -r '.Account.Id' < "${account_file}" )"
+    account_mappings+=(["${aws_id}"]="${account_id}")
+  done
+
+  readarray -t cf_dirs < <(find "${root_dir}" -type d -name "cf" )
+  for cf_dir in "${cf_dirs[@]}"; do
+    readarray -t cmk_stacks < <(find "${cf_dir}" -type f -name "seg-cmk-*[0-9]-stack.json" )
+    for cmk_stack in "${cmk_stacks[@]}"; do
+
+      info "Looking for CMK account in ${cmk_stack} ..."
+      cmk_account="$( jq -r '.Stacks[0].Outputs[] | select( .OutputKey=="Account" ) | .OutputValue' < "${cmk_stack}" )"
+
+      if [[ -n "${cmk_account}" ]]; then
+        cmk_account_id="${account_mappings[${cmk_account}]}"
+        cmk_path="$(filePath "${cmk_stack}")"
+
+        readarray -t segment_cf < <(find "${cmk_path}"  -type f )
+        for cf_file in "${segment_cf[@]}"; do
+
+          parse_stack_filename "${cf_file}"
+          stack_dir="$(filePath "${cf_file}")"
+
+          if [[ -z "${stack_account}" ]]; then
+
+            # Rename file to inclue Region and Account
+            cf_file_name="$(fileName "${cf_file}" )"
+            new_cf_file_name="${cf_file_name/"-${stack_region}-"/-${cmk_account_id}-${stack_region}-}"
+
+            move_file=1
+            if [[ "${cf_file_name}" != "${new_cf_file_name}" && "${cf_file_name}" != *"${cmk_account_id}"* ]]; then
+              if [[ -e "${stack_dir}/${new_cf_file_name}" ]]; then
+                diff "${cf_file}" "${stack_dir}/${new_cf_file_name}" > /dev/null
+                if [[ $? -eq 0 ]]; then
+                  move_file=0
+                else
+                  fatal "Rename failed - ${stack_dir}/${new_cf_file_name} already exists. Manual intervention necessary."
+                  return_status=1
+                  break
+                fi
+              fi
+
+              if [[ "${move_file}" != 0 ]]; then
+                debug "Moving ${cf_file} to ${stack_dir}/${new_cf_file_name} ..."
+              else
+                warning "${cf_file} already upgraded - removing ..."
+              fi
+
+              if [[ -n "${dry_run}" ]]; then
+                continue
+              fi
+
+              if [[ "${move_file}" != 0 ]]; then
+                git_mv "${cf_file}" "${stack_dir}/${new_cf_file_name}"
+              else
+                git_rm "${cf_file}"
+              fi
+            fi
+          fi
+        done
+      fi
+      [[ "${return_status}" -ne 0 ]] && break
+    done
+    [[ "${return_status}" -ne 0 ]] && break
+  done
+
+  popTempDir
+
+  return $return_status
+}
+
+function upgrade_cmdb_repo_to_v1_3_2() {
+  # Rerun 1.3.1 to pick up errors in original implementation
+  # Should be a no-op when run immediately after current 1.3.1
+  # implementation
+  upgrade_cmdb_repo_to_v1_3_1 "$@"
+}
+
+function upgrade_cmdb_repo_to_v2_0_0() {
+  # Reorganise cmdb to make it easier to manage via branches and dynamic cmdbs
+  #
+  # State is now in its own directory at the same level as config and infrastructure
+  # Solutions is now under infrastructure
+  # Builds are separated from settings and are now under infrastructure
+  # Operations are now in their own directory at same level as config and
+  # infrastructure. For consistency with config, a settings subdirectory has been
+  # added.
+  #
+  # With this layout,
+  # - infrastructure should be the same across environments assuming no builds
+  #   are being promoted
+  # - product and operations settings are managed consistently
+  # - all the state info is cleanly separated (so potentially in its own repo)
+  #
+  # /config/settings
+  # /operations/settings
+  # /infrastructure/solutions
+  # /infrastructure/builds
+  # /state/cf
+  # /state/cot
+  #
+  # If config and infrastructure are not in the one repo, then the upgrade must
+  # be performed manually and the cmdb version manually updated
+  local root_dir="$1";shift
+  local dry_run="$1";shift
+
+
+  pushTempDir "${FUNCNAME[0]}_$(fileName "${root_dir}")_XXXX"
+  local tmp_dir="$(getTopTempDir)"
+  local return_status=0
+
+  readarray -t config_dirs < <(find "${root_dir}" -type d -name "config" )
+  for config_dir in "${config_dirs[@]}"; do
+    local base_dir="$(filePath "${config_dir}")"
+    local config_dir="${base_dir}/config"
+    local infrastructure_dir="${base_dir}/infrastructure"
+    local state_dir="${base_dir}/state"
+    local operations_dir="${base_dir}/operations"
+
+    local state_subdirs=("${infrastructure_dir}/cf" "${infrastructure_dir}/cot")
+
+    if [[ -d "${infrastructure_dir}" ]]; then
+      debug "${dry_run}Checking ${base_dir} ..."
+
+      # Move the state into its own top level tree
+      mkdir -p "${state_dir}"
+      for state_subdir in "${state_subdirs[@]}"; do
+        if [[ -d "${state_subdir}" ]]; then
+          info "${dry_run}Moving ${state_subdir} to ${state_dir} ..."
+          [[ -n "${dry_run}" ]] && continue
+          git_mv "${state_subdir}" "${state_dir}" || { return_status=1; break; }
+        fi
+      done
+
+      # Move operations settings into their own top level tree
+      orig_operations_settings_dir="${infrastructure_dir}/operations"
+      new_operations_settings_dir="${operations_dir}/settings"
+      if [[ -d "${orig_operations_settings_dir}" ]]; then
+        info "${dry_run}Moving ${orig_operations_settings_dir} to ${new_operations_settings_dir} ..."
+        [[ -n "${dry_run}" ]] && continue
+        if [[ ! -d "${new_operations_settings_dir}" ]]; then
+          mkdir -p "${operations_dir}"
+          git_mv "${orig_operations_settings_dir}" "${new_operations_settings_dir}" || { return_status=1; break; }
+        fi
+      fi
+
+      # Copy the solutions tree from config to infrastructure and rename
+      local solutions_dir="${config_dir}/solutionsv2"
+      if [[ -d "${solutions_dir}" ]]; then
+        info "${dry_run}Copying ${solutions_dir} to ${infrastructure_dir} ..."
+        if [[ -z "${dry_run}" ]]; then
+          # Leave existing solutions dir in place as it may be the current directory
+          cp -pr "${solutions_dir}" "${infrastructure_dir}" || return_status=1
+        fi
+        info "${dry_run}Renaming ${infrastructure_dir}/solutionsv2 to ${infrastructure_dir}/solutions ..."
+        if [[ -z "${dry_run}" ]]; then
+          mv "${infrastructure_dir}/solutionsv2" "${infrastructure_dir}/solutions"
+        fi
+      fi
+
+      # Copy the builds into their own tree
+      local settings_dir="${config_dir}/settings"
+      local builds_dir="${infrastructure_dir}/builds"
+      if [[ ! -d "${builds_dir}" ]]; then
+        info "${dry_run}Copying ${settings_dir} to ${builds_dir} ..."
+        if [[ -z "${dry_run}" ]]; then
+          cp -pr "${settings_dir}" "${builds_dir}"
+        fi
+      fi
+
+      # Remove the build files from the settings tree
+      # Blob will pick up build references and shared builds
+      info "${dry_run}Cleaning the settings tree ..."
+      readarray -t setting_files < <(find "${settings_dir}" -type f \( \
+        -name "*build.json" \) )
+      for setting_file in "${setting_files[@]}"; do
+        info "${dry_run}Deleting ${setting_file} ..."
+        [[ -n "${dry_run}" ]] && continue
+        git_rm "${setting_file}" || { return_status=1; break; }
+      done
+
+      # Build tree should only contain build references and shared builds
+      info "${dry_run}Cleaning the builds tree ..."
+      [[ -n "${dry_run}" ]] &&
+        readarray -t build_files < <(find "${settings_dir}"   -type f \( \
+        -not -name "*build.json" \) ) ||
+        readarray -t build_files < <(find "${builds_dir}"   -type f \( \
+        -not -name "*build.json" \) )
+      for build_file in "${build_files[@]}"; do
+        info "${dry_run}Deleting ${build_file} ..."
+        [[ -n "${dry_run}" ]] && continue
+        rm "${build_file}" || { return_status=1; break; }
+      done
+
+    else
+      warn "${dry_run}Update to v2.0.0 for ${config_dir} must be manually performed for split cmdb repos"
+    fi
+  done
+
+  popTempDir
+
+  return $return_status
+}
+
+declare -A gen3_compatability
+# TODO: Align to GEN3 framework version where v2.0.0 format is to be introduced
+gen3_compatability=(
+  ["2.0.0"]=">=7.0.0"
+)
+
+function is_upgrade_compatible() {
+  local cmdb_version="$(semver_clean "$1")"; shift
+  local gen3_version="$1"; shift
+
+  local compatible_range="${gen3_compatability[${cmdb_version}]}"
+
+  if [[ -n "${compatible_range}" ]]; then
+
+    # Must know the gen3 version
+    [[ -z "${gen3_version}" ]] && return 2
+
+    semver_satisfies "${gen3_version}" "${compatible_range}"
+    return $?
+  fi
+
+  # Upgrade is compatible
+  return 0
+}
+
 function process_cmdb() {
   local root_dir="$1";shift
   local action="$1";shift
+  local gen3_version="$1";shift
   local version_list="$1";shift
   local dry_run="${1:+(Dryrun) }";shift
 
@@ -1159,7 +1708,22 @@ function process_cmdb() {
         continue
       fi
 
+      # Ensure current gen3 framework version is compatible with the upgrade
+      is_upgrade_compatible "${version}" "${gen3_version}"; upgrade_status=$?
+      case "${upgrade_status}" in
+        2)
+          warn "${dry_run}${action^} of repo "${cmdb_repo}" to ${version} requires the GEN3 framework version to be defined. Skipping upgrade process ..."
+          break
+          ;;
+        1)
+          warn "${dry_run}${action^} of repo "${cmdb_repo}" to ${version} is not compatible with the current gen3 framework version of ${gen3_version}. Skipping upgrade process ..."
+          break
+          ;;
+      esac
+
+      pushd "${cmdb_repo}" > /dev/null 2>&1
       ${action,,}_cmdb_repo_to_${version//./_} "${cmdb_repo}" "${dry_run}"; return_status=$?
+      popd > /dev/null 2>&1
 
       if [[ "${return_status}" -eq 0 ]]; then
         # Only check the first version to be applied for a dryrun
@@ -1187,21 +1751,24 @@ function process_cmdb() {
 
 function upgrade_cmdb() {
   local root_dir="$1";shift
+  local gen3_version="$1";shift
   local dry_run="$1";shift
   local versions="$1";shift
 
   local required_versions=(${versions})
-  [[ -z "${versions}" ]] && required_versions=("v1.0.0" "v1.1.0")
+  [[ -z "${versions}" ]] && required_versions=("v1.0.0" "v1.1.0" "v1.2.0" "v1.3.0" "v1.3.1" "v1.3.2")
 
-  process_cmdb "${root_dir}" "upgrade" "${required_versions[*]}" ${dry_run}
+  process_cmdb "${root_dir}" "upgrade" "${gen3_version}" "${required_versions[*]}" ${dry_run}
 }
 
 function cleanup_cmdb() {
   local root_dir="$1";shift
+  local gen3_version="$1";shift
   local dry_run="$1";shift
+  local versions="$1";shift
 
   local required_versions=(${versions})
-  [[ -z "${versions}" ]] && required_versions=("v1.0.0")
+  [[ -z "${versions}" ]] && required_versions=("v1.0.0" "v1.1.0" "v1.1.1")
 
-  process_cmdb "${root_dir}" "cleanup" "${required_versions[*]}" ${dry_run}
+  process_cmdb "${root_dir}" "cleanup" "${gen3_version}" "${required_versions[*]}" ${dry_run}
 }

--- a/jenkins/aws/promoteRelease.sh
+++ b/jenkins/aws/promoteRelease.sh
@@ -32,10 +32,10 @@ if [[ "${RELEASE_MODE}" == "${RELEASE_MODE_PROMOTION}" ]]; then
     mv "${FROM_PRODUCT_TEMP_DIR}" "${FROM_PRODUCT_ROOT_DIR}"
 
     # Find the product appsettings directory
-    FROM_SETTINGS_DIR="$(findGen3ProductDir "${FROM_PRODUCT_BASE_DIR}" "${PRODUCT}")/settings/${FROM_ENVIRONMENT}/${SEGMENT}"
-            
+    FROM_BUILDS_DIR="$(findGen3ProductBuildsDir "${FROM_PRODUCT_BASE_DIR}" "${PRODUCT}")/${FROM_ENVIRONMENT}/${SEGMENT}"
+
     # Pull in the current build references in lower segment
-    ${AUTOMATION_DIR}/manageBuildReferences.sh -f -g ${FROM_SETTINGS_DIR}
+    ${AUTOMATION_DIR}/manageBuildReferences.sh -f -g ${FROM_BUILDS_DIR}
     RESULT=$? && [[ "${RESULT}" -ne 0 ]] && exit
 fi
 

--- a/setContext.sh
+++ b/setContext.sh
@@ -309,17 +309,10 @@ function main() {
             AUTOMATION_BUILD_SRC_DIR="${AUTOMATION_BUILD_DIR}/${BUILD_SRC_DIR}" ||
             { fatal "Build source directory ${BUILD_SRC_DIR} not found"; exit; }
       else
-        [[ -d "${AUTOMATION_BUILD_DIR}/src" ]] &&
-            AUTOMATION_BUILD_SRC_DIR="${AUTOMATION_BUILD_DIR}/src"
-
-        [[ -d "${AUTOMATION_BUILD_DIR}/app" ]] &&
-            AUTOMATION_BUILD_SRC_DIR="${AUTOMATION_BUILD_DIR}/app"
-
-        [[ -d "${AUTOMATION_BUILD_DIR}/content" ]] &&
-            AUTOMATION_BUILD_SRC_DIR="${AUTOMATION_BUILD_DIR}/content"
-
-        [[ -d "${AUTOMATION_BUILD_DIR}/pkg" ]] &&
-            AUTOMATION_BUILD_SRC_DIR="${AUTOMATION_BUILD_DIR}/pkg"
+        for sub_dir in "src" "app" "content" "pkg" "package" "content"; do
+            [[ -d "${AUTOMATION_BUILD_DIR}/${sub_dir}" ]] &&
+                AUTOMATION_BUILD_SRC_DIR="${AUTOMATION_BUILD_DIR}/${sub_dir}"
+        done
       fi
 
       # Build devops directory
@@ -338,7 +331,7 @@ function main() {
       save_context_property AUTOMATION_DATA_DIR "${WORKSPACE}"
 
       # Build devops directory
-      [[ -d "${WORKSPACE}/devops" ]] && 
+      [[ -d "${WORKSPACE}/devops" ]] &&
         save_context_property AUTOMATION_BUILD_DIR "${WORKSPACE}/devops"
       [[ -d "${WORKSPACE}/deploy" ]] &&
         save_context_property AUTOMATION_BUILD_DIR "${WORKSPACE}/deploy"
@@ -437,7 +430,7 @@ function main() {
   # - provider
   findAndDefineSetting "ACCOUNT_PROVIDER" "ACCOUNT_PROVIDER" "${ACCOUNT}" "" "value" "aws"
   AUTOMATION_DIR="${AUTOMATION_PROVIDER_DIR}/${ACCOUNT_PROVIDER}"
-  
+
 
   # - access credentials
   case "${ACCOUNT_PROVIDER}" in


### PR DESCRIPTION
This commit is the automation companion of the equivalent gen3 change.

The only specific change required for automation was to change build
promotion to use the new PRODUCT_BUILDS_DIR variable to locate where the
builds to be promoted should come from.

utility.sh and contextTree.sh have also been updated to pick up the
refactored directory location logic.
