### PR TITLE
setCredentials for Azure subscriptions

### DIFF
--- a/jenkins/aws/setCredentials.sh
+++ b/jenkins/aws/setCredentials.sh
@@ -6,78 +6,118 @@
 #
 # $1 = account to be accessed
 
-AWS_CRED_ACCOUNT="${1^^}"
+# Determine which provider to authenticate
+ACCOUNT_PROVIDER_DEFAULT="AWS"
+ACCOUNT_PROVIDER=${ACCOUNT_PROVIDER:=${ACCOUNT_PROVIDER_DEFAULT}}
 
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 
-# Clear any previous results
-unset AWS_CRED_AWS_ACCESS_KEY_ID_VAR
-unset AWS_CRED_AWS_SECRET_ACCESS_KEY_VAR
-unset AWS_CRED_TEMP_AWS_ACCESS_KEY_ID
-unset AWS_CRED_TEMP_AWS_SECRET_ACCESS_KEY
-unset AWS_CRED_TEMP_AWS_SESSION_TOKEN
+case ${ACCOUNT_PROVIDER} in
 
-# Determine default maximum validity period - align to role default
-AUTOMATION_ROLE_VALIDITY="${AUTOMATION_ROLE_VALIDITY:-3600}"
+  AWS)
+    # setCredentials in AWS works with "accounts"
+    PROVIDER_CRED_ACCOUNT="${1^^}"
 
-# First check for account specific credentials
-AWS_CRED_OVERRIDE_AWS_ACCESS_KEY_ID_VAR="${AWS_CRED_ACCOUNT}_AWS_ACCESS_KEY_ID"
-AWS_CRED_OVERRIDE_AWS_SECRET_ACCESS_KEY_VAR="${AWS_CRED_ACCOUNT}_AWS_SECRET_ACCESS_KEY"
-if [[ (-n "${!AWS_CRED_OVERRIDE_AWS_ACCESS_KEY_ID_VAR}") && (-n "${!AWS_CRED_OVERRIDE_AWS_SECRET_ACCESS_KEY_VAR}") ]]; then
-    AWS_CRED_AWS_ACCESS_KEY_ID_VAR="${AWS_CRED_OVERRIDE_AWS_ACCESS_KEY_ID_VAR}"
-    AWS_CRED_AWS_SECRET_ACCESS_KEY_VAR="${AWS_CRED_OVERRIDE_AWS_SECRET_ACCESS_KEY_VAR})"
-else
-    # Check for a global automation user/role
-    AWS_CRED_AWS_ACCOUNT_ID_VAR="${AWS_CRED_ACCOUNT}_AWS_ACCOUNT_ID"
-    AWS_CRED_AUTOMATION_USER_VAR="${AWS_CRED_ACCOUNT}_AUTOMATION_USER"
-    if [[ -z "${!AWS_CRED_AUTOMATION_USER_VAR}" ]]; then AWS_CRED_AUTOMATION_USER_VAR="AWS_AUTOMATION_USER"; fi
-    AWS_CRED_AUTOMATION_ROLE_VAR="${AWS_CRED_ACCOUNT}_AUTOMATION_ROLE"
-    if [[ -z "${!AWS_CRED_AUTOMATION_ROLE_VAR}" ]]; then AWS_CRED_AUTOMATION_ROLE_VAR="AWS_AUTOMATION_ROLE"; fi
-    AWS_CRED_AUTOMATION_ROLE="${!AWS_CRED_AUTOMATION_ROLE_VAR:-codeontap-automation}"
+    # Clear any previous results
+    unset AWS_CRED_AWS_ACCESS_KEY_ID_VAR
+    unset AWS_CRED_AWS_SECRET_ACCESS_KEY_VAR
+    unset AWS_CRED_TEMP_AWS_ACCESS_KEY_ID
+    unset AWS_CRED_TEMP_AWS_SECRET_ACCESS_KEY
+    unset AWS_CRED_TEMP_AWS_SESSION_TOKEN
 
-    if [[ (-n ${!AWS_CRED_AWS_ACCOUNT_ID_VAR}) && (-n ${!AWS_CRED_AUTOMATION_USER_VAR}) ]]; then
-        # Assume automation role either
-        # - using the role we are current running under, or
-        # - using credentails associated with the automation user
-        # Note that the value for the user is just a way to obtain the access credentials
-        # and doesn't have to be the same as the IAM user associated with the credentials
-        if [[ "${!AWS_CRED_AUTOMATION_USER_VAR^^}" == "ROLE" ]]; then
-            # Clear any use of previously obtained credentials
-            unset AWS_ACCESS_KEY_ID
-            unset AWS_SECRET_ACCESS_KEY
-        else
-            # Not using current role so determine the credentials
-            AWS_CRED_AWS_ACCESS_KEY_ID_VAR="${!AWS_CRED_AUTOMATION_USER_VAR^^}_AWS_ACCESS_KEY_ID"
-            AWS_CRED_AWS_SECRET_ACCESS_KEY_VAR="${!AWS_CRED_AUTOMATION_USER_VAR^^}_AWS_SECRET_ACCESS_KEY"
-            AWS_CRED_AWS_ACCESS_KEY_ID="${!AWS_CRED_AWS_ACCESS_KEY_ID_VAR}"
-            AWS_CRED_AWS_SECRET_ACCESS_KEY="${!AWS_CRED_AWS_SECRET_ACCESS_KEY_VAR}"
+    # Determine default maximum validity period - align to role default
+    AUTOMATION_ROLE_VALIDITY="${AUTOMATION_ROLE_VALIDITY:-3600}"
 
-            if [[ (-n ${AWS_CRED_AWS_ACCESS_KEY_ID}) && (-n ${AWS_CRED_AWS_SECRET_ACCESS_KEY}) ]]; then
-                export AWS_ACCESS_KEY_ID="${AWS_CRED_AWS_ACCESS_KEY_ID}"
-                export AWS_SECRET_ACCESS_KEY="${AWS_CRED_AWS_SECRET_ACCESS_KEY}"
+    # First check for account specific credentials
+    AWS_CRED_OVERRIDE_AWS_ACCESS_KEY_ID_VAR="${PROVIDER_CRED_ACCOUNT}_AWS_ACCESS_KEY_ID"
+    AWS_CRED_OVERRIDE_AWS_SECRET_ACCESS_KEY_VAR="${PROVIDER_CRED_ACCOUNT}_AWS_SECRET_ACCESS_KEY"
+    if [[ (-n "${!AWS_CRED_OVERRIDE_AWS_ACCESS_KEY_ID_VAR}") && (-n "${!AWS_CRED_OVERRIDE_AWS_SECRET_ACCESS_KEY_VAR}") ]]; then
+        AWS_CRED_AWS_ACCESS_KEY_ID_VAR="${AWS_CRED_OVERRIDE_AWS_ACCESS_KEY_ID_VAR}"
+        AWS_CRED_AWS_SECRET_ACCESS_KEY_VAR="${AWS_CRED_OVERRIDE_AWS_SECRET_ACCESS_KEY_VAR})"
+    else
+        # Check for a global automation user/role
+        AWS_CRED_AWS_ACCOUNT_ID_VAR="${PROVIDER_CRED_ACCOUNT}_AWS_ACCOUNT_ID"
+        AWS_CRED_AUTOMATION_USER_VAR="${PROVIDER_CRED_ACCOUNT}_AUTOMATION_USER"
+        if [[ -z "${!AWS_CRED_AUTOMATION_USER_VAR}" ]]; then AWS_CRED_AUTOMATION_USER_VAR="AWS_AUTOMATION_USER"; fi
+        AWS_CRED_AUTOMATION_ROLE_VAR="${PROVIDER_CRED_ACCOUNT}_AUTOMATION_ROLE"
+        if [[ -z "${!AWS_CRED_AUTOMATION_ROLE_VAR}" ]]; then AWS_CRED_AUTOMATION_ROLE_VAR="AWS_AUTOMATION_ROLE"; fi
+        AWS_CRED_AUTOMATION_ROLE="${!AWS_CRED_AUTOMATION_ROLE_VAR:-codeontap-automation}"
+
+        if [[ (-n ${!AWS_CRED_AWS_ACCOUNT_ID_VAR}) && (-n ${!AWS_CRED_AUTOMATION_USER_VAR}) ]]; then
+            # Assume automation role either
+            # - using the role we are current running under, or
+            # - using credentails associated with the automation user
+            # Note that the value for the user is just a way to obtain the access credentials
+            # and doesn't have to be the same as the IAM user associated with the credentials
+            if [[ "${!AWS_CRED_AUTOMATION_USER_VAR^^}" == "ROLE" ]]; then
+                # Clear any use of previously obtained credentials
+                unset AWS_ACCESS_KEY_ID
+                unset AWS_SECRET_ACCESS_KEY
+            else
+                # Not using current role so determine the credentials
+                AWS_CRED_AWS_ACCESS_KEY_ID_VAR="${!AWS_CRED_AUTOMATION_USER_VAR^^}_AWS_ACCESS_KEY_ID"
+                AWS_CRED_AWS_SECRET_ACCESS_KEY_VAR="${!AWS_CRED_AUTOMATION_USER_VAR^^}_AWS_SECRET_ACCESS_KEY"
+                AWS_CRED_AWS_ACCESS_KEY_ID="${!AWS_CRED_AWS_ACCESS_KEY_ID_VAR}"
+                AWS_CRED_AWS_SECRET_ACCESS_KEY="${!AWS_CRED_AWS_SECRET_ACCESS_KEY_VAR}"
+
+                if [[ (-n ${AWS_CRED_AWS_ACCESS_KEY_ID}) && (-n ${AWS_CRED_AWS_SECRET_ACCESS_KEY}) ]]; then
+                    export AWS_ACCESS_KEY_ID="${AWS_CRED_AWS_ACCESS_KEY_ID}"
+                    export AWS_SECRET_ACCESS_KEY="${AWS_CRED_AWS_SECRET_ACCESS_KEY}"
+                fi
             fi
-        fi
 
-        if [[ ("${!AWS_CRED_AUTOMATION_USER_VAR^^}" == "ROLE") ||
-              ((-n ${AWS_CRED_AWS_ACCESS_KEY_ID}) && (-n ${AWS_CRED_AWS_SECRET_ACCESS_KEY})) ]]; then
-            TEMP_CREDENTIAL_FILE="${AUTOMATION_DATA_DIR}/temp_aws_credentials.json"
-            unset AWS_SESSION_TOKEN
+            if [[ ("${!AWS_CRED_AUTOMATION_USER_VAR^^}" == "ROLE") ||
+                  ((-n ${AWS_CRED_AWS_ACCESS_KEY_ID}) && (-n ${AWS_CRED_AWS_SECRET_ACCESS_KEY})) ]]; then
+                TEMP_CREDENTIAL_FILE="${AUTOMATION_DATA_DIR}/temp_aws_credentials.json"
+                unset AWS_SESSION_TOKEN
 
-            aws sts assume-role \
-                --role-arn arn:aws:iam::${!AWS_CRED_AWS_ACCOUNT_ID_VAR}:role/${AWS_CRED_AUTOMATION_ROLE} \
-                --role-session-name "$(echo $GIT_USER | tr -cd '[[:alnum:]]' )" \
-                --duration-seconds "${AUTOMATION_ROLE_VALIDITY}" \
-                --output json > ${TEMP_CREDENTIAL_FILE} ||
                 aws sts assume-role \
                     --role-arn arn:aws:iam::${!AWS_CRED_AWS_ACCOUNT_ID_VAR}:role/${AWS_CRED_AUTOMATION_ROLE} \
                     --role-session-name "$(echo $GIT_USER | tr -cd '[[:alnum:]]' )" \
-                    --output json > ${TEMP_CREDENTIAL_FILE}
-            unset AWS_ACCESS_KEY_ID
-            unset AWS_SECRET_ACCESS_KEY
-            AWS_CRED_TEMP_AWS_ACCESS_KEY_ID=$(jq -r '.Credentials.AccessKeyId' < ${TEMP_CREDENTIAL_FILE})
-            AWS_CRED_TEMP_AWS_SECRET_ACCESS_KEY=$(jq -r '.Credentials.SecretAccessKey' < ${TEMP_CREDENTIAL_FILE})
-            AWS_CRED_TEMP_AWS_SESSION_TOKEN=$(jq -r '.Credentials.SessionToken' < ${TEMP_CREDENTIAL_FILE})
-            rm ${TEMP_CREDENTIAL_FILE}
+                    --duration-seconds "${AUTOMATION_ROLE_VALIDITY}" \
+                    --output json > ${TEMP_CREDENTIAL_FILE} ||
+                    aws sts assume-role \
+                        --role-arn arn:aws:iam::${!AWS_CRED_AWS_ACCOUNT_ID_VAR}:role/${AWS_CRED_AUTOMATION_ROLE} \
+                        --role-session-name "$(echo $GIT_USER | tr -cd '[[:alnum:]]' )" \
+                        --output json > ${TEMP_CREDENTIAL_FILE}
+                unset AWS_ACCESS_KEY_ID
+                unset AWS_SECRET_ACCESS_KEY
+                AWS_CRED_TEMP_AWS_ACCESS_KEY_ID=$(jq -r '.Credentials.AccessKeyId' < ${TEMP_CREDENTIAL_FILE})
+                AWS_CRED_TEMP_AWS_SECRET_ACCESS_KEY=$(jq -r '.Credentials.SecretAccessKey' < ${TEMP_CREDENTIAL_FILE})
+                AWS_CRED_TEMP_AWS_SESSION_TOKEN=$(jq -r '.Credentials.SessionToken' < ${TEMP_CREDENTIAL_FILE})
+                rm ${TEMP_CREDENTIAL_FILE}
+            fi
         fi
     fi
-fi
+  ;;
+  AZURE)
+
+    # setCredentials in Azure works with "subscriptions"
+    SUBSCRIPTION="${1}"
+    pushTempDir "set_credentials_XXXXXX"
+    tmp_dir="$(getTopTempDir)"
+    tmpdir="${tmp_dir}"
+
+    # remove any cached subscriptions
+    unset TARGET_SUBSCRIPTION
+
+    # Obtain current subscription list
+    TEMP_SUBSCRIPTION_FILE="${tmpdir}/temp_azure_subscriptions.json"
+    az account list --all --refresh --output json > ${TEMP_SUBSCRIPTION_FILE}
+
+    # Check account has access to target subscription
+    TARGET_SUBSCRIPTION=$(jq --arg sub ${SUBSCRIPTION} '.[] | select(.name == $sub)' < ${TEMP_SUBSCRIPTION_FILE})
+    [[ -z ${TARGET_SUBSCRIPTION} ]] && 
+      fatal "Subscription ${SUBSCRIPTION} either does not exist, or cannot be accessed by current account."
+
+    # Set subscription as default if not already
+    [[ $(echo ${TARGET_SUBSCRIPTION} | jq '.isDefault') == false ]] &&
+      az account set --subscription "${SUBSCRIPTION}" --output none
+  ;;
+  *)
+    fatal "Provider ${ACCOUNT_PROVIDER} is not yet supported for setCredentials."
+  ;;
+
+esac
+
+

--- a/setContext.sh
+++ b/setContext.sh
@@ -417,15 +417,19 @@ function main() {
   AUTOMATION_DIR="${AUTOMATION_PROVIDER_DIR}/${ACCOUNT_PROVIDER}"
 
   # - access credentials
-  case "${ACCOUNT_PROVIDER}" in
-      aws)
-          . ${AUTOMATION_DIR}/setCredentials.sh "${ACCOUNT}"
-          save_context_property ACCOUNT_AWS_ACCESS_KEY_ID_VAR      "${AWS_CRED_AWS_ACCESS_KEY_ID_VAR}"
-          save_context_property ACCOUNT_AWS_SECRET_ACCESS_KEY_VAR  "${AWS_CRED_AWS_SECRET_ACCESS_KEY_VAR}"
-          save_context_property ACCOUNT_TEMP_AWS_ACCESS_KEY_ID     "${AWS_CRED_TEMP_AWS_ACCESS_KEY_ID}"
-          save_context_property ACCOUNT_TEMP_AWS_SECRET_ACCESS_KEY "${AWS_CRED_TEMP_AWS_SECRET_ACCESS_KEY}"
-          save_context_property ACCOUNT_TEMP_AWS_SESSION_TOKEN     "${AWS_CRED_TEMP_AWS_SESSION_TOKEN}"
-          ;;
+  case "${ACCOUNT_PROVIDER^^}" in
+      AWS)
+        . ${AUTOMATION_DIR}/setCredentials.sh "${ACCOUNT}"
+        save_context_property ACCOUNT_AWS_ACCESS_KEY_ID_VAR      "${AWS_CRED_AWS_ACCESS_KEY_ID_VAR}"
+        save_context_property ACCOUNT_AWS_SECRET_ACCESS_KEY_VAR  "${AWS_CRED_AWS_SECRET_ACCESS_KEY_VAR}"
+        save_context_property ACCOUNT_TEMP_AWS_ACCESS_KEY_ID     "${AWS_CRED_TEMP_AWS_ACCESS_KEY_ID}"
+        save_context_property ACCOUNT_TEMP_AWS_SECRET_ACCESS_KEY "${AWS_CRED_TEMP_AWS_SECRET_ACCESS_KEY}"
+        save_context_property ACCOUNT_TEMP_AWS_SESSION_TOKEN     "${AWS_CRED_TEMP_AWS_SESSION_TOKEN}"
+        ;;
+      AZURE)
+        # "ACCOUNT" here is an Azure "subscription".
+        . ${AUTOMATION_DIR}/setCredentials.sh "${ACCOUNT}"
+        ;;
   esac
 
   # - cmdb git provider


### PR DESCRIPTION
- existing setCredentials for AWS into a case-statement on the existing ACCOUNT_PROVIDER var
- defaults to AWS if no ACCOUNT_PROVIDER var found
- implemented matching functionality for the AZURE provider.

Closes codeontap/gen3-azure#17
 