### PR TITLE
<refactor> Docs blueprint generation optional

### DIFF
--- a/jenkins/aws/manageUnits.sh
+++ b/jenkins/aws/manageUnits.sh
@@ -161,7 +161,8 @@ function main() {
       # - Currently the blueprint only generates a segment level blueprin
       if [[ "${level}" != "account" && "${level}" != "product" && "${GENERATION_DOCS_BLUEPRINT}" == "true" ]]; then
           info "Generating deployment blueprint... \n"
-          ${GENERATION_DIR}/createTemplate.sh -l blueprint || return $?
+          ${GENERATION_DIR}/createTemplate.sh -l blueprint  2>/dev/null || 
+              { warning "An issue occurred generating the blueprint - This will not break things but could be an issue" }
       fi
     done
   done

--- a/jenkins/aws/manageUnits.sh
+++ b/jenkins/aws/manageUnits.sh
@@ -4,6 +4,9 @@
 trap 'exit 1' SIGHUP SIGINT SIGTERM
 . "${AUTOMATION_BASE_DIR}/common.sh"
 
+#Defaults 
+DEFAULT_GENERATION_DOCS_BLUEPRINT="false"
+
 function usage() {
     cat <<EOF
 
@@ -31,12 +34,14 @@ where
 (o) -r REFERENCE              reference to use when preparing templates
 (o) -s SOLUTION_UNITS_LIST    is the list of solution level units to process
 (o) -u MULTIPLE_UNITS_LIST    is the list of multi-level units to process
+(o) -b GENERATION_DOCS_BLUEPRINT  create a build print for documentation
 
 (m) mandatory, (o) optional, (d) deprecated
 
 DEFAULTS:
 
 ACCOUNT_LIST=\${ACCOUNT}
+GENERATION_DOCS_BLUEPRINT=${DEFAULT_GENERATION_DOCS_BLUEPRINT
 
 NOTES:
 
@@ -48,9 +53,10 @@ EOF
 
 function options() {
     # Parse options
-    while getopts ":a:c:g:hl:m:n:p:r:s:u:" option; do
+    while getopts ":a:bc:g:hl:m:n:p:r:s:u:" option; do
         case $option in
             a) APPLICATION_UNITS_LIST="${OPTARG}" ;;
+            b) GENERATION_DOCS_BLUEPRINT="true" ;;
             c) ACCOUNT_UNITS_LIST="${OPTARG}" ;;
             g) SEGMENT_UNITS_LIST="${OPTARG}" ;;
             h) usage; return 1 ;;
@@ -72,6 +78,8 @@ function options() {
 function main() {
 
   options "$@" || return $?
+
+  GENERATION_DOCS_BLUEPRINT="${GENERATION_DOCS_BLUEPRINT:-${DEFAULT_GENERATION_DOCS_BLUEPRINT}}"
 
   # Process each account
   arrayFromList accounts_required "${ACCOUNTS_LIST:-${ACCOUNT}}"
@@ -150,8 +158,8 @@ function main() {
       done
       
       # Update blueprint if a stack is being managed
-      # - Currently the blueprint only generates a segment level blueprint
-      if [[ "${level}" != "account" && "${level}" != "product" ]]; then
+      # - Currently the blueprint only generates a segment level blueprin
+      if [[ "${level}" != "account" && "${level}" != "product" && "${GENERATION_DOCS_BLUEPRINT}" == "true" ]]; then
           info "Generating deployment blueprint... \n"
           ${GENERATION_DIR}/createTemplate.sh -l blueprint || return $?
       fi


### PR DESCRIPTION
Make the documentation blueprint optional. 
This feature is mostly experimental and really only used if infradocs is deployed. This should speed up deployments as it can be enabled on a case by case basis