### PR TITLE
Feat azpipelines

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -51,9 +51,6 @@ function save_context_property() {
   local name="$1"; shift
   local value="$1"; shift
   local file="${1:-${AUTOMATION_DATA_DIR}/context.properties}"; shift
-
-  local AUTOMATION_ENGINE_DEFAULT="jenkins"
-  local engine="${${AUTOMATION_ENGINE}:-${AUTOMATION_ENGINE_DEFAULT}}"
   
   if [[ -n "${value}" ]]; then
     local property_value="${value}"
@@ -65,12 +62,15 @@ function save_context_property() {
     fi
   fi
 
-  case "${AUTOMATION_ENGINE}" in
+  case "${AUTOMATION_PROVIDER}" in
     jenkins)
       echo "${name}=${property_value}" >> "${file}"
       ;;
-    azurePipelines)
+    azurepipelines)
+      export ${name}="${property_value}"
+      set +x
       echo "##vso[task.setvariable variable=${name}]${property_value}"
+      set -x
       ;;
   esac
 }
@@ -80,6 +80,7 @@ function save_chain_property() {
   local value="$1"; shift
 
   save_context_property "${name}" "${value}" "${AUTOMATION_DATA_DIR}/chain.properties"
+  
 }
 
 function define_context_property() {

--- a/common.sh
+++ b/common.sh
@@ -67,9 +67,11 @@ function save_context_property() {
       echo "${name}=${property_value}" >> "${file}"
       ;;
     azurepipelines)
-      export ${name}="${property_value}"
+      # remove trailing whitespace from any var about to be set
+      property_value_nospace=$(echo "${property_value}" | sed -e 's/[[:space:]]*$//')
+      export ${name}="${property_value_nospace}"
       set +x
-      echo "##vso[task.setvariable variable=${name}]${property_value}"
+      echo "##vso[task.setvariable variable=${name}]${property_value_nospace}"
       set -x
       ;;
   esac

--- a/common.sh
+++ b/common.sh
@@ -51,6 +51,9 @@ function save_context_property() {
   local name="$1"; shift
   local value="$1"; shift
   local file="${1:-${AUTOMATION_DATA_DIR}/context.properties}"; shift
+
+  local AUTOMATION_ENGINE_DEFAULT="jenkins"
+  local engine="${${AUTOMATION_ENGINE}:-${AUTOMATION_ENGINE_DEFAULT}}"
   
   if [[ -n "${value}" ]]; then
     local property_value="${value}"
@@ -62,7 +65,14 @@ function save_context_property() {
     fi
   fi
 
-  echo "${name}=${property_value}" >> "${file}"
+  case "${AUTOMATION_ENGINE}" in
+    jenkins)
+      echo "${name}=${property_value}" >> "${file}"
+      ;;
+    azurePipelines)
+      echo "##vso[task.setvariable variable=${name}]${property_value}"
+      ;;
+  esac
 }
 
 function save_chain_property() {

--- a/jenkins/aws/buildJekyll.sh
+++ b/jenkins/aws/buildJekyll.sh
@@ -35,7 +35,11 @@ function main() {
     JEKYLL_ENV="production"
   fi
 
-  mkdir "${dockerstagedir}/indir"
+  #TODO(rossmurr4y): There is an issue in Jekyll where it may not create
+  # the cache dir correctly. This is listed as resolved in the next Jekyll
+  # version. At that point, this should be returned to creating the empty
+  # indir directory.
+  mkdir -p "${dockerstagedir}/indir/.jekyll-cache"
   cp -r "${AUTOMATION_BUILD_SRC_DIR}"/*  "${dockerstagedir}/indir/"
 
   # Create Build folders for Jenkins Permissions

--- a/setContext.sh
+++ b/setContext.sh
@@ -256,11 +256,14 @@ function main() {
     AUTOMATION_PROVIDER="${AUTOMATION_PROVIDER:-jenkins}"
   fi
   AUTOMATION_PROVIDER="${AUTOMATION_PROVIDER,,}"
-  AUTOMATION_PROVIDER_DIR="${AUTOMATION_BASE_DIR}/${AUTOMATION_PROVIDER}"
+  # TODO(rossmurr4y): Update to use AUTOMATION_PROVIDER once there is more than the jenkins provider dir.
+  # AUTOMATION_PROVIDER_DIR="${AUTOMATION_BASE_DIR}/${AUTOMATION_PROVIDER}"
+  AUTOMATION_PROVIDER_DIR="${AUTOMATION_BASE_DIR}/jenkins"
 
 
   ### Context from automation provider ###
 
+  # TODO(rossmurr4y): seperate out azure pipelines
   case "${AUTOMATION_PROVIDER}" in
     jenkins)
       # Determine the aggregator/integrator/tenant/product/environment/segment from
@@ -326,6 +329,22 @@ function main() {
       # Job identifier
       AUTOMATION_JOB_IDENTIFIER="${BUILD_NUMBER}"
       ;;
+    azurepipelines)
+      save_context_property GIT_USER "${GIT_USER:-$BUILD_USER}"
+      save_context_property GIT_EMAIL "${GIT_EMAIL:-$BUILD_USER_EMAIL}"
+      save_context_property AUTOMATION_DATA_DIR "${WORKSPACE}"
+
+      # Build devops directory
+      [[ -d "${WORKSPACE}/devops" ]] && 
+        save_context_property AUTOMATION_BUILD_DIR "${WORKSPACE}/devops"
+      [[ -d "${WORKSPACE}/deploy" ]] &&
+        save_context_property AUTOMATION_BUILD_DIR "${WORKSPACE}/deploy"
+      [[ -z "${WORKSPACE}" ]] &&
+        save_context_property AUTOMATION_BUILD_DIR "${WORKSPACE}"
+
+      save_context_property AUTOMATION_BUILD_SRC_DIR "${WORKSPACE}"
+      save_context_property AUTOMATION_BUILD_DEVOPS_DIR "${WORKSPACE}"
+    ;;
   esac
 
   # Parse options
@@ -415,6 +434,7 @@ function main() {
   # - provider
   findAndDefineSetting "ACCOUNT_PROVIDER" "ACCOUNT_PROVIDER" "${ACCOUNT}" "" "value" "aws"
   AUTOMATION_DIR="${AUTOMATION_PROVIDER_DIR}/${ACCOUNT_PROVIDER}"
+  
 
   # - access credentials
   case "${ACCOUNT_PROVIDER}" in
@@ -520,7 +540,7 @@ function main() {
 
   # Capture any provided git commit
   case ${AUTOMATION_PROVIDER} in
-      jenkins)
+      jenkins | azurepipelines)
           [[ -n "${GIT_COMMIT}" ]] && CODE_COMMIT_ARRAY[0]="${GIT_COMMIT}"
           ;;
   esac


### PR DESCRIPTION
Incorporated a number of minor changes that allow for Azure Pipelines builds.

Where jenkins builds output properties to context.properties file and read the file regularly, Pipelines allows you to echo comments in such a way as to set a variable that is available in subsequent build steps. Because they aren't immediately available, we also export the variable to be available within the same step.

``` example
echo "##vso[task.setvariable variable=myVariableName]myVariableValue"
```

There is also currently an issue in Jekyll (https://github.com/jekyll/jekyll/issues/7591) when run from Azure Pipelines that prevents the cache dir from creating (subsequently failing the build). I have implemented a minor change here to the creation of the "indir" temp directory to also create the child".jekyll-cache" at the same time, with the intention of reverting this once the issue has been deployed to jekyll proper (looks like its the next release).