### PR TITLE
<refactor> Support relative paths in openapi assembly

### DIFF
--- a/setContext.sh
+++ b/setContext.sh
@@ -301,8 +301,8 @@ function main() {
       # Build source directory
       AUTOMATION_BUILD_SRC_DIR="${AUTOMATION_BUILD_DIR}"
 
-      if [[ -n "${BUILD_SRC_DIR}" ]]; then 
-        [[ -d "${AUTOMATION_BUILD_DIR}/${BUILD_SRC_DIR}" ]] && 
+      if [[ -n "${BUILD_SRC_DIR}" ]]; then
+        [[ -d "${AUTOMATION_BUILD_DIR}/${BUILD_SRC_DIR}" ]] &&
             AUTOMATION_BUILD_SRC_DIR="${AUTOMATION_BUILD_DIR}/${BUILD_SRC_DIR}" ||
             { fatal "Build source directory ${BUILD_SRC_DIR} not found"; exit; }
       else
@@ -314,6 +314,9 @@ function main() {
 
         [[ -d "${AUTOMATION_BUILD_DIR}/content" ]] &&
             AUTOMATION_BUILD_SRC_DIR="${AUTOMATION_BUILD_DIR}/content"
+
+        [[ -d "${AUTOMATION_BUILD_DIR}/pkg" ]] &&
+            AUTOMATION_BUILD_SRC_DIR="${AUTOMATION_BUILD_DIR}/pkg"
       fi
 
       # Build devops directory


### PR DESCRIPTION
relative paths can reference anywhere in the repo, not just within the build dir. Thus we need to take a copy of the repo tree including any files that might be needed (.yaml or .json)