### PR TITLE
<fix> RDS Snapshot tags on copy

### DIFF
--- a/jenkins/aws/manageRdssnapshot.sh
+++ b/jenkins/aws/manageRdssnapshot.sh
@@ -266,7 +266,7 @@ case ${SNAPSHOT_OPERATION} in
         info "Copying Snapshot from: ${SNAPSHOT_SOURCE} to: ${SNAPSHOT_IMAGE}"
 
         # A build will create a new snapshot we just need to bring it into the registry
-        aws --region "${SNAPSHOT_PROVIDER_REGION}" rds copy-db-snapshot --source-db-snapshot-identifier "${SNAPSHOT_SOURCE}" --target-db-snapshot-identifier "${SNAPSHOT_IMAGE}" --copy-tags || exit $?
+        aws --region "${SNAPSHOT_PROVIDER_REGION}" rds copy-db-snapshot --source-db-snapshot-identifier "${SNAPSHOT_SOURCE}" --target-db-snapshot-identifier "${SNAPSHOT_IMAGE}" --no-copy-tags --tags Key=RegistrySnapshot,Value="true" || exit $?
 
         info "Waiting for snapshot to become available..."
         sleep 2
@@ -348,7 +348,7 @@ case ${SNAPSHOT_OPERATION} in
                 setCredentials "${SNAPSHOT_PROVIDER}"
 
                 # A build will create a new snapshot we just need to bring it into the registry
-                LOCAL_SNAPSHOT_IMAGE_ARN="$(aws --region "${SNAPSHOT_PROVIDER_REGION}" rds copy-db-snapshot --source-db-snapshot-identifier "${SNAPSHOT_SNAPSHOT_ARN}" --target-db-snapshot-identifier "${SNAPSHOT_IMAGE}" --query 'DBSnapshot.DBSnapshotArn' --copy-tags --output text || exit $?)"
+                LOCAL_SNAPSHOT_IMAGE_ARN="$(aws --region "${SNAPSHOT_PROVIDER_REGION}" rds copy-db-snapshot --source-db-snapshot-identifier "${SNAPSHOT_SNAPSHOT_ARN}" --target-db-snapshot-identifier "${SNAPSHOT_IMAGE}" --query 'DBSnapshot.DBSnapshotArn' --tags Key=RegistrySnapshot,Value="true" --no-copy-tags --output text || exit $?)"
 
                 if [[ -n "${LOCAL_SNAPSHOT_IMAGE_ARN}" ]]; then
                     info "Waiting for snapshot to become available..."


### PR DESCRIPTION
Can't copy tags across shared snapshots so we need to add them back on after a copy