### PR TITLE
<fix> Only save stacks on success

### DIFF
--- a/jenkins/aws/deploy.sh
+++ b/jenkins/aws/deploy.sh
@@ -11,7 +11,7 @@ function main() {
         TAG="deploy${AUTOMATION_JOB_IDENTIFIER}-${PRODUCT}-${ENVIRONMENT}-${SEGMENT}"
     fi
     # Create the templates
-    ${AUTOMATION_DIR}/manageUnits.sh -l "application" -a "${DEPLOYMENT_UNIT_LIST}" -r "${PRODUCT_CONFIG_COMMIT}"
+    ${AUTOMATION_DIR}/manageUnits.sh -l "application" -a "${DEPLOYMENT_UNIT_LIST}" -r "${PRODUCT_CONFIG_COMMIT}" || return $?
 
     # All ok so tag the config repo
     save_product_config "${DETAIL_MESSAGE}" "${PRODUCT_CONFIG_REFERENCE}" "${TAG}" || return $?
@@ -19,4 +19,5 @@ function main() {
     # Commit the generated application templates
     save_product_infrastructure "${DETAIL_MESSAGE}" "${PRODUCT_INFRASTRUCTURE_REFERENCE}" "${TAG}" || return $?
 }
+
 main "$@"


### PR DESCRIPTION
The saving of stacks was recently added to deploy. However the return code from the stack operation was not being checking, resulting in the stack being overwritten with rollback information.