### PR TITLE
<feature> Dynamic assembly of openapi files

### DIFF
--- a/jenkins/aws/buildOpenapi.sh
+++ b/jenkins/aws/buildOpenapi.sh
@@ -43,6 +43,12 @@ fi
 
 # Possible input files
 OPENAPI_SPEC_FILE=$(findFile \
+                    "${AUTOMATION_BUILD_DIR}/build/openapi.json" \
+                    "${AUTOMATION_BUILD_DIR}/build/openapi.yml" \
+                    "${AUTOMATION_BUILD_DIR}/build/openapi.yaml" \
+                    "${AUTOMATION_BUILD_DIR}/build/swagger.json" \
+                    "${AUTOMATION_BUILD_DIR}/build/swagger.yml" \
+                    "${AUTOMATION_BUILD_DIR}/build/swagger.yaml" \
                     "${AUTOMATION_BUILD_DIR_PARENT}/**/*spec/${BUILD_DIR}/openapi.json" \
                     "${AUTOMATION_BUILD_DIR_PARENT}/**/*spec/${BUILD_DIR}/openapi.yml" \
                     "${AUTOMATION_BUILD_DIR_PARENT}/**/*spec/${BUILD_DIR}/openapi.yaml" \


### PR DESCRIPTION
When looking for an openapi spec, first check for a file in a "build" subdirectory.

This permits the addition of a step in the build job to run something to assemble the spec based on whatever rules the coder chooses to apply.

As an example, buildJS.sh can be run as a step before buildSwagger.sh to use a package.json file to specify a "build" target to assemble the spec into the build subdirectory.

The extra step can also do things like linting and testing the spec.